### PR TITLE
feat: update DIDComm json message types

### DIFF
--- a/src/domain/models/Message.ts
+++ b/src/domain/models/Message.ts
@@ -142,7 +142,8 @@ export class Message implements Pluto.Storable {
   }
 
   static isJsonAttachment(data: any): data is AttachmentJsonData {
-    return data.data !== undefined || data.json !== undefined;
+    // data.data handled for backwards compatibility with stored messages
+    return data.json !== undefined || data.data !== undefined;
   }
 }
 
@@ -173,12 +174,9 @@ export namespace Message {
       }
 
       if (isJson(attachment.data)) {
-        let decoded: any;
-        if ("data" in attachment.data) {
-          decoded = attachment.data.data;
-        } else if ("json" in attachment.data) {
-          decoded = attachment.data.json;
-        }
+        // data.data handled for backwards compatibility
+        const decoded = attachment.data.json ?? (attachment.data as any).data;
+
         return typeof decoded === "object"
           ? decoded
           : JSON.parse(decoded);
@@ -193,8 +191,8 @@ export namespace Message {
     };
 
     const isJson = (data: AttachmentData): data is AttachmentJsonData => {
-      // ?? why do we mutate json -> data in didcomm Wrapper
-      return "data" in data || "json" in data;
+      // data.data handled for backwards compatibility
+      return "json" in data || "data" in data;
     };
   }
 }

--- a/src/domain/models/MessageAttachment.ts
+++ b/src/domain/models/MessageAttachment.ts
@@ -27,8 +27,6 @@ export interface AttachmentLinkData {
 
 export type AttachmentJsonData = {
   json: any;
-} | {
-  data: any;
 };
 
 export type AttachmentData =

--- a/src/edge-agent/protocols/pickup/PickupRunner.ts
+++ b/src/edge-agent/protocols/pickup/PickupRunner.ts
@@ -5,9 +5,9 @@ import { ProtocolType } from "../ProtocolTypes";
 import { PickupAttachment } from "../types";
 
 type PickupResponse =
-  | { type: "status"; message: Message }
-  | { type: "delivery"; message: Message }
-  | { type: 'report', message: Message };
+  | { type: "status"; message: Message; }
+  | { type: "delivery"; message: Message; }
+  | { type: 'report', message: Message; };
 
 export class PickupRunner {
   private message: PickupResponse;
@@ -41,9 +41,7 @@ export class PickupRunner {
     } else if (Message.isJsonAttachment(attachment.data)) {
       return {
         attachmentId: attachment.id,
-        data: "data" in attachment.data ?
-          JSON.stringify(attachment.data.data) :
-          JSON.stringify(attachment.data.json),
+        data: JSON.stringify(attachment.data.json),
       };
     }
 
@@ -56,7 +54,7 @@ export class PickupRunner {
     return attachment !== null;
   }
 
-  async run(): Promise<Array<{ attachmentId: string; message: Message }>> {
+  async run(): Promise<Array<{ attachmentId: string; message: Message; }>> {
     if (this.message.type === "delivery") {
       return Promise.all(
         this.message.message.attachments
@@ -73,7 +71,7 @@ export class PickupRunner {
           attachmentId: this.message.message.id,
           message: this.message.message
         }
-      ]
+      ];
     }
 
     return [];

--- a/src/mercury/didcomm/Wrapper.ts
+++ b/src/mercury/didcomm/Wrapper.ts
@@ -174,29 +174,11 @@ export class DIDCommWrapper implements DIDCommProtocol {
   private parseAttachmentDataToDomain(
     data: AttachmentData
   ): Domain.AttachmentData {
-    if ("base64" in data) {
-      const parsed: Domain.AttachmentBase64 = {
-        base64: data.base64,
-      };
-
-      return parsed;
-    }
-
-    if ("json" in data) {
-      const parsed: Domain.AttachmentJsonData = {
-        data: data.json,
-      };
-
-      return parsed;
-    }
-
-    if ("links" in data) {
-      const parsed: Domain.AttachmentLinkData = {
-        hash: data.hash,
-        links: data.links,
-      };
-
-      return parsed;
+    if ("base64" in data
+      || "json" in data
+      || "links" in data
+    ) {
+      return data;
     }
 
     throw new MercuryError.UnknownAttachmentDataError();
@@ -246,14 +228,6 @@ export class DIDCommWrapper implements DIDCommProtocol {
         json: typeof data.json === "string" ?
           JSON.parse(data.json) :
           data.json,
-      };
-
-      return parsed;
-    }
-
-    if ("data" in data) {
-      const parsed: JsonAttachmentData = {
-        json: JSON.parse(data.data),
       };
 
       return parsed;

--- a/src/mercury/forward/ForwardMessage.ts
+++ b/src/mercury/forward/ForwardMessage.ts
@@ -19,7 +19,7 @@ export class ForwardMessage {
   makeMessage(): Message {
     const body = JSON.stringify(this.body);
     const attachment = new AttachmentDescriptor(
-      { data: this.encryptedMessage },
+      { json: this.encryptedMessage },
       "application/json"
     );
     return new Message(body, this.id, ForwardMessage.type, this.from, this.to, [


### PR DESCRIPTION
### Description: 
Fixing the mutation of json attachments into data property.
For the sake of backwards compatibility with existing dbs I've left the comparison logic for existing messages, and just changed the code so all new messages will correctly use the `json` property

BREAKING CHANGES:
  - AttachmentDescriptor will now only knowingly accept body's with `json` property.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
