### PR TITLE
fix: improving presentation exchange verification flow

### DIFF
--- a/src/plugins/internal/dif/PresentationVerify.ts
+++ b/src/plugins/internal/dif/PresentationVerify.ts
@@ -51,6 +51,164 @@ export class PresentationVerify extends Plugins.Task<Args> {
     return typeof data === "object" ? true : false;
   }
 
+  private async verifySDJWT(
+    ctx: Context,
+    presentationRequest: DIF.Presentation.Request,
+    inputDescriptors: DIF.Presentation.Definition.InputDescriptor[],
+    mapper: DescriptorPath,
+    item: DIF.Presentation.Submission.DescriptorItem
+  ) {
+    const jws = expect(
+      mapper.getValue(item.path),
+      `Invalid Submission, ${item.path} not found in submission`
+    );
+
+    const presentation = SDJWTCredential.fromJWS(jws);
+    if ("challenge" in presentationRequest && "domain" in presentationRequest) {
+      const challenge = presentationRequest?.challenge;
+
+      if (challenge && challenge !== '') {
+        const nonce = presentation.getProperty("nonce");
+
+        if (!nonce || typeof nonce !== "string") {
+          throw new Error(`Invalid Submission, ${item.path} does not contain a nonce in its payload with a valid signature for '${challenge}'`);
+        }
+        if (nonce !== challenge) {
+          throw new Error(`Invalid Submission, ${item.path} does not contain valid signature for '${challenge}'`);
+        }
+      }
+    }
+
+
+    // [ ] https://github.com/hyperledger/identus-edge-agent-sdk-ts/issues/366
+    // should fail when credential invalid - requiredClaims need to be passed
+    // const requiredClaims = asArray(this.args.requiredClaims);
+    // const credentialValid = await ctx.SDJWT.verify({
+    //   issuerDID: issuer,
+    //   jws,
+    //   requiredClaimKeys: requiredClaims
+    // });
+
+    const claims = await ctx.SDJWT.reveal(
+      presentation.core.jwt?.payload ?? {},
+      presentation.core.disclosures ?? [],
+    );
+    const verifiableCredentialPropsMapper = new DescriptorPath(claims);
+    const inputDescriptor = inputDescriptors.find(
+      (inputDescriptor) => inputDescriptor.id === item.id
+    );
+
+    const valid = this.validateInputDescriptor(
+      presentation.id,
+      verifiableCredentialPropsMapper,
+      inputDescriptor
+    );
+
+    return valid;
+  }
+
+  private async verifyJWT(
+    ctx: Context,
+    presentationRequest: DIF.Presentation.Request,
+    inputDescriptors: DIF.Presentation.Definition.InputDescriptor[],
+    mapper: DescriptorPath,
+    item: DIF.Presentation.Submission.DescriptorItem
+  ) {
+    const jws = expect(
+      mapper.getValue(item.path),
+      new Domain.PolluxError.InvalidVerifyFormatError(
+        `Invalid Submission, ${item.path} not found in submission`
+      )
+    );
+
+    const presentation = JWTCredential.fromJWS(jws);
+    const issuer = presentation.issuer;
+
+    // [ ] https://github.com/hyperledger/identus-edge-agent-sdk-ts/issues/367
+    // handle challenge, domain and nonce according to spec https://identity.foundation/presentation-exchange/
+    // const presentationDefinitionOptions = presentationRequest;
+
+    // if ("challenge" in presentationDefinitionOptions && "domain" in presentationDefinitionOptions) {
+    //   const challenge = presentationDefinitionOptions?.challenge;
+    //   if (challenge && challenge !== '') {
+    //     const nonce = presentation.getProperty('nonce');
+
+    //     if (!nonce || typeof nonce !== "string") {
+    //       throw new Domain.PolluxError.InvalidVerifyCredentialError(jws, `Invalid Submission, ${descriptorItem.path} does not contain a nonce in its payload with a valid signature for '${challenge}'`);
+    //     }
+    //     if (nonce !== challenge) {
+    //       throw new Domain.PolluxError.InvalidVerifyCredentialError(jws, `Invalid Submission, ${descriptorItem.path} does not contain valid signature for '${challenge}'`);
+    //     }
+    //   }
+    // }
+
+    // if (presentation.credentialType !== Domain.CredentialType.JWT) {
+    //   throw new Domain.PolluxError.InvalidVerifyCredentialError(jws, "Invalid JWT Credential only jwt or sdjwt is supported for jwt submission");
+    // }
+
+    const credentialValid = await ctx.JWT.verify({ issuerDID: issuer, jws });
+
+    if (!credentialValid) {
+      throw new Domain.PolluxError.InvalidVerifyCredentialError(jws, "Invalid Holder Presentation JWS Signature");
+    }
+
+    // if (descriptorItem.format !== OEA.JWT_VP) {
+    //   throw new Error("");
+    // }
+
+    const nestedPath = item.path_nested;
+
+    if (!nestedPath) {
+      throw new Domain.PolluxError.InvalidVerifyFormatError(
+        `Invalid Submission, ${item.path} of format "jwt_vp" must provide a nested_path with "jwt_vc" for JWT`
+      );
+    }
+
+    const verifiableCredentialMapper = new DescriptorPath(presentation);
+    const vc = verifiableCredentialMapper.getValue(nestedPath.path);
+
+    if (!vc) {
+      throw new Domain.PolluxError.InvalidVerifyCredentialError(jws, "Invalid Verifiable Presentation payload, cannot find vc");
+    }
+    const verifiableCredential = JWTCredential.fromJWS(vc);
+    try {
+      const revocationTask = new IsCredentialRevoked({ credential: verifiableCredential });
+      const isRevoked = await ctx.run(revocationTask);
+
+      if (isRevoked.data) {
+        throw new Domain.PolluxError.InvalidVerifyCredentialError(vc, "Invalid Verifiable Presentation, credential is revoked");
+      }
+    } catch (err) {
+      if (err instanceof Domain.PolluxError.InvalidVerifyCredentialError) {
+        throw err;
+      } else {
+        throw new Domain.PolluxError.InvalidVerifyCredentialError(vc, `Invalid Verifiable Presentation, could not verify if the credential is revoked, reason: ${(err as Error).message}`);
+      }
+    }
+
+    if (verifiableCredential.subject !== issuer) {
+      throw new Domain.PolluxError.InvalidVerifyCredentialError(vc, "Invalid Verifiable Presentation payload, the credential has been issued to another holder");
+    }
+
+    const verifiableCredentialValid = await ctx.JWT.verify({
+      holderDID: verifiableCredential.subject ? Domain.DID.fromString(verifiableCredential.subject) : undefined,
+      issuerDID: verifiableCredential.issuer,
+      jws: verifiableCredential.id
+    });
+    if (!verifiableCredentialValid) {
+      throw new Domain.PolluxError.InvalidVerifyCredentialError(vc, "Invalid Presentation Credential JWS Signature");
+    }
+    const verifiableCredentialPropsMapper = new DescriptorPath(verifiableCredential);
+    const inputDescriptor = inputDescriptors.find((inputDescriptor) => inputDescriptor.id === item.id);
+
+    return this.validateInputDescriptor(
+      vc,
+      verifiableCredentialPropsMapper,
+      inputDescriptor
+    );
+
+  }
+
   private async verify(
     ctx: Context,
     presentationSubmission: DIF.EmbedTarget,
@@ -60,221 +218,129 @@ export class PresentationVerify extends Plugins.Task<Args> {
     const presentationSubmissionMapper = new DescriptorPath(presentationSubmission);
     const descriptorMaps = presentationSubmission.presentation_submission.descriptor_map;
 
-    // BUG [https://github.com/hyperledger/identus-edge-agent-sdk-ts/issues/365]
-    // for loop will exit on first return statement?
+    // return true if 
     for (const descriptorItem of descriptorMaps) {
       if (descriptorItem.format === "sdjwt" as any) {
-        const jws = expect(
-          presentationSubmissionMapper.getValue(descriptorItem.path),
-          `Invalid Submission, ${descriptorItem.path} not found in submission`
-        );
-
-        const presentation = SDJWTCredential.fromJWS(jws);
-        // const issuer = presentation.issuer;
-
-        if ("challenge" in presentationRequest && "domain" in presentationRequest) {
-          const challenge = presentationRequest?.challenge;
-
-          if (challenge && challenge !== '') {
-            const nonce = presentation.getProperty("nonce");
-
-            if (!nonce || typeof nonce !== "string") {
-              throw new Error(`Invalid Submission, ${descriptorItem.path} does not contain a nonce in its payload with a valid signature for '${challenge}'`);
-            }
-            if (nonce !== challenge) {
-              throw new Error(`Invalid Submission, ${descriptorItem.path} does not contain valid signature for '${challenge}'`);
-            }
-          }
+        const valid = await this.verifySDJWT(
+          ctx,
+          presentationRequest,
+          inputDescriptors,
+          presentationSubmissionMapper,
+          descriptorItem
+        )
+        if (valid) {
+          return true;
         }
-
-        // [ ] https://github.com/hyperledger/identus-edge-agent-sdk-ts/issues/366
-        // should fail when credential invalid - requiredClaims need to be passed
-        // const requiredClaims = asArray(this.args.requiredClaims);
-        // const credentialValid = await ctx.SDJWT.verify({
-        //   issuerDID: issuer,
-        //   jws,
-        //   requiredClaimKeys: requiredClaims
-        // });
-
-        const claims = await ctx.SDJWT.reveal(
-          presentation.core.jwt?.payload ?? {},
-          presentation.core.disclosures ?? [],
+      } else if (descriptorItem.format === "jwt_vp") {
+        const valid = await this.verifyJWT(
+          ctx,
+          presentationRequest,
+          inputDescriptors,
+          presentationSubmissionMapper,
+          descriptorItem
+        )
+        if (valid) {
+          return true;
+        }
+      } else {
+        throw new Domain.PolluxError.InvalidVerifyFormatError(
+          `Invalid Submission, ${descriptorItem.path} expected to have format "jwt_vp"`
         );
-        const verifiableCredentialPropsMapper = new DescriptorPath(claims);
-        const inputDescriptor = inputDescriptors.find((inputDescriptor) => inputDescriptor.id === descriptorItem.id);
-
-        this.validateInputDescriptor(
-          presentation.id,
-          verifiableCredentialPropsMapper,
-          inputDescriptor
-        );
-        return true;
       }
+    }
+    return false;
+  }
 
-      if (descriptorItem.format === "jwt_vp") {
-        const jws = presentationSubmissionMapper.getValue(descriptorItem.path);
-
-        if (!jws) {
-          throw new Domain.PolluxError.InvalidVerifyFormatError(`Invalid Submission, ${descriptorItem.path} not found in submission`);
-        }
-
-        const presentation = JWTCredential.fromJWS(jws);
-        const issuer = presentation.issuer;
-
-        // [ ] https://github.com/hyperledger/identus-edge-agent-sdk-ts/issues/367
-        // handle challenge, domain and nonce according to spec https://identity.foundation/presentation-exchange/
-        // const presentationDefinitionOptions = presentationRequest;
-
-        // if ("challenge" in presentationDefinitionOptions && "domain" in presentationDefinitionOptions) {
-        //   const challenge = presentationDefinitionOptions?.challenge;
-        //   if (challenge && challenge !== '') {
-        //     const nonce = presentation.getProperty('nonce');
-
-        //     if (!nonce || typeof nonce !== "string") {
-        //       throw new Domain.PolluxError.InvalidVerifyCredentialError(jws, `Invalid Submission, ${descriptorItem.path} does not contain a nonce in its payload with a valid signature for '${challenge}'`);
-        //     }
-        //     if (nonce !== challenge) {
-        //       throw new Domain.PolluxError.InvalidVerifyCredentialError(jws, `Invalid Submission, ${descriptorItem.path} does not contain valid signature for '${challenge}'`);
-        //     }
-        //   }
-        // }
-
-        // if (presentation.credentialType !== Domain.CredentialType.JWT) {
-        //   throw new Domain.PolluxError.InvalidVerifyCredentialError(jws, "Invalid JWT Credential only jwt or sdjwt is supported for jwt submission");
-        // }
-
-        const credentialValid = await ctx.JWT.verify({ issuerDID: issuer, jws });
-
-        if (!credentialValid) {
-          throw new Domain.PolluxError.InvalidVerifyCredentialError(jws, "Invalid Holder Presentation JWS Signature");
-        }
-
-        // if (descriptorItem.format !== OEA.JWT_VP) {
-        //   throw new Error("");
-        // }
-
-        const nestedPath = descriptorItem.path_nested;
-
-        if (!nestedPath) {
-          throw new Domain.PolluxError.InvalidVerifyFormatError(
-            `Invalid Submission, ${descriptorItem.path} of format "jwt_vp" must provide a nested_path with "jwt_vc" for JWT`
-          );
-        }
-
-        const verifiableCredentialMapper = new DescriptorPath(presentation);
-        const vc = verifiableCredentialMapper.getValue(nestedPath.path);
-
-        if (!vc) {
-          throw new Domain.PolluxError.InvalidVerifyCredentialError(jws, "Invalid Verifiable Presentation payload, cannot find vc");
-        }
-        const verifiableCredential = JWTCredential.fromJWS(vc);
-        try {
-          const revocationTask = new IsCredentialRevoked({ credential: verifiableCredential });
-          const isRevoked = await ctx.run(revocationTask);
-
-          if (isRevoked.data) {
-            throw new Domain.PolluxError.InvalidVerifyCredentialError(vc, "Invalid Verifiable Presentation, credential is revoked");
-          }
-        } catch (err) {
-          throw new Domain.PolluxError.InvalidVerifyCredentialError(vc, `Invalid Verifiable Presentation, could not verify if the credential is revoked, reason: ${(err as Error).message}`);
-        }
-
-        if (verifiableCredential.subject !== issuer) {
-          throw new Domain.PolluxError.InvalidVerifyCredentialError(vc, "Invalid Verifiable Presentation payload, the credential has been issued to another holder");
-        }
-
-        const verifiableCredentialValid = await ctx.JWT.verify({
-          holderDID: verifiableCredential.subject ? Domain.DID.fromString(verifiableCredential.subject) : undefined,
-          issuerDID: verifiableCredential.issuer,
-          jws: verifiableCredential.id
-        });
-        if (!verifiableCredentialValid) {
-          throw new Domain.PolluxError.InvalidVerifyCredentialError(vc, "Invalid Presentation Credential JWS Signature");
-        }
-        const verifiableCredentialPropsMapper = new DescriptorPath(verifiableCredential);
-        const inputDescriptor = inputDescriptors.find((inputDescriptor) => inputDescriptor.id === descriptorItem.id);
-
-        this.validateInputDescriptor(
-          vc,
-          verifiableCredentialPropsMapper,
-          inputDescriptor
-        );
-        return true;
-      }
-
-      throw new Domain.PolluxError.InvalidVerifyFormatError(
-        `Invalid Submission, ${descriptorItem.path} expected to have format "jwt_vp"`
+  private validateField(
+    vc: string,
+    mapper: DescriptorPath,
+    path: string | undefined,
+    field: DIF.Presentation.Definition.Field,
+  ) {
+    if (!path) {
+      throw new Domain.PolluxError.InvalidVerifyCredentialError(
+        vc,
+        `Invalid Claim: Expected one of the paths ${field.path.join(", ")} to exist.`
       );
     }
 
-    return false;
+    const value = mapper.getValue(path);
+
+    if (field.filter && value !== null) {
+      const filter = field.filter;
+
+      if (filter.pattern) {
+        const pattern = new RegExp(filter.pattern);
+        if (!pattern.test(value) && value !== filter.pattern) {
+          throw new Domain.PolluxError.InvalidVerifyCredentialError(
+            vc, `Invalid Claim: Expected the ${path} field to be "${filter.pattern}" but got "${value}"`
+          )
+        } else {
+          return true;
+        }
+
+      } else if (filter.enum) {
+        if (!filter.enum.includes(value)) {
+          throw new Domain.PolluxError.InvalidVerifyCredentialError(
+            vc, `Invalid Claim: Expected the ${path} field to be one of ${filter.enum.join(", ")} but got ${value}`
+          )
+        } else {
+          return true
+        }
+
+      } else if (filter.const && value === filter.pattern) {
+        if (value !== filter.const) {
+          throw new Domain.PolluxError.InvalidVerifyCredentialError(
+            vc, `Invalid Claim: Expected the ${path} field to be "${filter.const}" but got "${value}"`
+          )
+        } else {
+          return true;
+        }
+
+      }
+    }
+
+    throw new Domain.PolluxError.InvalidVerifyCredentialError(
+      vc, `Invalid Claim: Expected one of the paths ${field.path.join(", ")} to exist.`
+    )
   }
 
   private validateInputDescriptor(
     vc: any,
     descriptorMapper: DescriptorPath,
-    inputDescriptor?: DIF.Presentation.Definition.InputDescriptor
+    inputDescriptor: DIF.Presentation.Definition.InputDescriptor | undefined
   ) {
-    if (inputDescriptor) {
-      const constraints = inputDescriptor.constraints;
-      const fields = constraints.fields;
+    if (!inputDescriptor) {
+      throw new Domain.PolluxError.InvalidVerifyFormatError(`Invalid Submission, undefined input descriptor`);
+    }
 
-      if (constraints.limit_disclosure === "required") {
-        for (const field of fields) {
-          const paths = [...field.path];
-          const optional = field.optional;
+    const constraints = inputDescriptor.constraints;
+    const fields = constraints.fields;
 
-          if (!optional) {
-            let validClaim = false;
-            let reason = null;
+    if (constraints.limit_disclosure === "required") {
+      for (const field of fields) {
+        const paths = [...field.path];
+        const optional = field.optional;
 
-            while (paths.length && !validClaim) {
-              const [path] = paths.splice(0, 1);
-
-              if (path) {
-                const fieldInVC = descriptorMapper.getValue(path);
-
-                if (field.filter && fieldInVC !== null) {
-                  const filter = field.filter;
-
-                  if (filter.pattern) {
-                    const pattern = new RegExp(filter.pattern);
-
-                    if (pattern.test(fieldInVC) || fieldInVC === filter.pattern) {
-                      validClaim = true;
-                    } else {
-                      reason = `Expected the ${path} field to be "${filter.pattern}" but got "${fieldInVC}"`;
-                    }
-                  } else if (filter.enum) {
-                    if (filter.enum.includes(fieldInVC)) {
-                      validClaim = true;
-                    } else {
-                      reason = `Expected the ${path} field to be one of ${filter.enum.join(", ")} but got ${fieldInVC}`;
-                    }
-
-                    validClaim = filter.enum.includes(fieldInVC);
-                  } else if (filter.const && fieldInVC === filter.pattern) {
-                    if (fieldInVC === filter.const) {
-                      validClaim = true;
-                    } else {
-                      reason = `Expected the ${path} field to be "${filter.const}" but got "${fieldInVC}"`;
-                    }
-
-                    validClaim = fieldInVC === filter.const;
-                  }
-                } else if (!reason) {
-                  reason = `Expected one of the paths ${field.path.join(", ")} to exist.`;
-                }
-              } else {
-                reason = `Expected one of the paths ${field.path.join(", ")} to exist.`;
-              }
+        if (!optional) {
+          let error: Error | undefined;
+          while (paths.length) {
+            const [path] = paths.splice(0, 1);
+            try {
+              this.validateField(vc, descriptorMapper, path, field);
+              return true;
+            } catch (err) {
+              //set error and continue to see if other paths succeed
+              error ??= err as Error;
             }
-            if (!validClaim) {
-              throw new Domain.PolluxError.InvalidVerifyCredentialError(vc, `Invalid Claim: ${reason || 'paths are not found or have unexpected value'}`);
-            }
+          }
+          if (error) {
+            throw error
           }
         }
       }
     }
+
+    return true;
   }
 }

--- a/tests/plugins/dif/PresentationVerify.test.ts
+++ b/tests/plugins/dif/PresentationVerify.test.ts
@@ -184,7 +184,7 @@ describe("Plugins - DIF", () => {
           const sut = new PresentationVerify({ presentation, presentationRequest: failRequest });
           const result = ctx.run(sut);
 
-          await expect(result).rejects.toThrow('Verification failed for credential (eyJhbGciOi...): reason -> Invalid Claim: Expected the $.credentialSubject.course field to be "not the expected pattern" but got "Identus Training course Certification 2024"');
+          await expect(result).rejects.toThrow('Verification failed for credential (eyJhbGciOi...): reason -> Invalid Claim: Expected the $.vc.credentialSubject.course field to be "not the expected pattern" but got "Identus Training course Certification 2024"');
         });
 
         test("invalid presentation - not an object - returns false", async () => {


### PR DESCRIPTION
### Description: 
Fixes the issue that @curtis-h spotted while refactoring to pollux plugins. During verification there's a loop and we were not properly validating all the edge cases properly + the code was hard to understand.

Have improved the verification process to make it easier to understand, there's many things to fix in there but have focused mainly on the loop and basic error handling.

All the tests are working

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
