### PR TITLE
fix: improve and standardize the DIF Presentation Exchange implementation

### DIFF
--- a/src/domain/models/VerifiableCredential.ts
+++ b/src/domain/models/VerifiableCredential.ts
@@ -23,21 +23,9 @@ export enum CredentialType {
   Unknown = "Unknown"
 }
 
-
-export enum W3CVerifiableCredentialContext {
-  credential = "https://www.w3.org/2018/credentials/v1",
-  revocation = "https://w3id.org/vc/status-list/2021/v1"
-}
-
-export enum W3CVerifiableCredentialType {
-  presentation = "VerifiablePresentation",
-  credential = "VerifiableCredential",
-  revocation = "StatusList2021Credential"
-}
-
 export type W3CVerifiableCredential = {
-  "@context": [W3CVerifiableCredentialContext.credential],
-  type: [W3CVerifiableCredentialType.credential],
+  "@context": ["https://www.w3.org/2018/credentials/v1"],
+  type: ["VerifiableCredential"],
   issuer: string,
   issuanceDate: string,
   issued?: string,
@@ -73,10 +61,10 @@ export type W3CVerifiableCredential = {
 
 export type W3CVerifiablePresentation = {
   "@context": [
-    W3CVerifiableCredentialContext.credential
+    "https://www.w3.org/2018/presentations/v1"
   ],
   type: [
-    W3CVerifiableCredentialType.presentation
+    "VerifiablePresentation"
   ],
   verifiableCredential: string[],
   proof?: W3CVerifiablePresentationProof;

--- a/src/domain/utils/JWT.ts
+++ b/src/domain/utils/JWT.ts
@@ -1,4 +1,3 @@
-import { JWTPayload } from "did-jwt";
 import { base64url } from "multiformats/bases/base64";
 import { isNil } from "../../utils/guards";
 import { InvalidJWTString } from "../models/errors/Pollux";

--- a/src/domain/utils/JWT.ts
+++ b/src/domain/utils/JWT.ts
@@ -3,6 +3,7 @@ import { base64url } from "multiformats/bases/base64";
 import { isNil } from "../../utils/guards";
 import { InvalidJWTString } from "../models/errors/Pollux";
 
+
 export namespace JWT {
   export interface Header {
     typ: string;

--- a/src/domain/utils/JWT.ts
+++ b/src/domain/utils/JWT.ts
@@ -2,6 +2,7 @@ import { JWTPayload } from "did-jwt";
 import { base64url } from "multiformats/bases/base64";
 import { isNil } from "../../utils/guards";
 import { InvalidJWTString } from "../models/errors/Pollux";
+import { JWTCredentialPayload, JWTPresentationPayload } from "../../pollux/models/JWTVerifiableCredential";
 
 
 export namespace JWT {
@@ -11,7 +12,7 @@ export namespace JWT {
     [key: string]: any;
   }
 
-  export type Payload = JWTPayload;
+  export type Payload = JWTCredentialPayload | JWTPresentationPayload;
 
   export interface DecodedObj {
     header: Header;

--- a/src/domain/utils/JWT.ts
+++ b/src/domain/utils/JWT.ts
@@ -1,7 +1,6 @@
 import { base64url } from "multiformats/bases/base64";
 import { isNil } from "../../utils/guards";
 import { InvalidJWTString } from "../models/errors/Pollux";
-import { JWTCredentialPayload, JWTPresentationPayload } from "../../pollux/models/JWTVerifiableCredential";
 import { JWTPayload } from "did-jwt";
 
 

--- a/src/domain/utils/JWT.ts
+++ b/src/domain/utils/JWT.ts
@@ -2,6 +2,7 @@ import { base64url } from "multiformats/bases/base64";
 import { isNil } from "../../utils/guards";
 import { InvalidJWTString } from "../models/errors/Pollux";
 import { JWTCredentialPayload, JWTPresentationPayload } from "../../pollux/models/JWTVerifiableCredential";
+import { JWTPayload } from "did-jwt";
 
 
 export namespace JWT {
@@ -11,7 +12,7 @@ export namespace JWT {
     [key: string]: any;
   }
 
-  export type Payload = JWTCredentialPayload | JWTPresentationPayload;
+  export type Payload = JWTPayload;
 
   export interface DecodedObj {
     header: Header;

--- a/src/plugins/internal/dif/PresentationRequest.ts
+++ b/src/plugins/internal/dif/PresentationRequest.ts
@@ -30,7 +30,7 @@ export class PresentationRequest extends Plugins.Task<Args> {
     const descriptorMap = inputDescriptors.map<DIF.Presentation.Submission.DescriptorItem>((inputDescriptor) => {
       if (credential instanceof SDJWTCredential) {
         return {
-          format: "sdjwt" as any,
+          format: "sd_jwt",
           id: inputDescriptor.id,
           path: "$.verifiablePresentation[0]",
         };
@@ -43,7 +43,7 @@ export class PresentationRequest extends Plugins.Task<Args> {
           path: "$.verifiablePresentation[0]",
           path_nested: {
             id: inputDescriptor.id,
-            format: 'jwt_vc',
+            format: "jwt_vc",
             path: "$.vp.verifiableCredential[0]",
           }
         };

--- a/src/plugins/internal/dif/PresentationRequest.ts
+++ b/src/plugins/internal/dif/PresentationRequest.ts
@@ -1,4 +1,5 @@
 import { uuid } from "@stablelib/uuid";
+import type { Extensible, PresentationFrame } from '@sd-jwt/types';
 import * as Domain from "../../../domain";
 import { JWTCredential } from "../../../pollux/models/JWTVerifiableCredential";
 import { SDJWTCredential } from "../../../pollux/models/SDJWTVerifiableCredential";
@@ -12,6 +13,7 @@ import { Plugins } from "../../../plugins";
 interface Args {
   credential: Domain.Credential;
   presentationRequest: DIF.Presentation.Request;
+  presentationFrame?: PresentationFrame<Extensible>;
 }
 
 export class PresentationRequest extends Plugins.Task<Args> {
@@ -79,9 +81,7 @@ export class PresentationRequest extends Plugins.Task<Args> {
       return ctx.SDJWT.createPresentationFor({
         jws: this.args.credential.id,
         privateKey,
-        // [ ] https://github.com/hyperledger-identus/sdk-ts/issues/362
-        // feature presentationFrame / frame
-        // presentationFrame: this.args.presentationFrame
+        presentationFrame: this.args.presentationFrame
       });
     }
 

--- a/src/plugins/internal/dif/PresentationVerify.ts
+++ b/src/plugins/internal/dif/PresentationVerify.ts
@@ -106,7 +106,6 @@ export class PresentationVerify extends Plugins.Task<Args> {
     try {
       const revocationTask = new IsCredentialRevoked({ credential: credential });
       const isRevoked = await ctx.run(revocationTask);
-
       if (isRevoked.data) {
         throw new Domain.PolluxError.InvalidVerifyCredentialError(credential.id, "Invalid Verifiable Presentation, credential is revoked");
       }
@@ -117,11 +116,6 @@ export class PresentationVerify extends Plugins.Task<Args> {
         throw new Domain.PolluxError.InvalidVerifyCredentialError(credential.id, `Invalid Verifiable Presentation, could not verify if the credential is revoked, reason: ${(err as Error).message}`);
       }
     }
-
-    //TOOD: VC Subject must match the Holder's presentation DID, a holder should never create a presentation on a credential that was not issued to him
-    // if (verifiableCredential.subject !== issuer) {
-    //   throw new Domain.PolluxError.InvalidVerifyCredentialError(vc, "Invalid Verifiable Presentation payload, the credential has been issued to another holder");
-    // 
 
     const mapper = new DescriptorPath(credential);
     for (const inputDescriptor of inputDescriptors) {

--- a/src/plugins/internal/dif/PresentationVerify.ts
+++ b/src/plugins/internal/dif/PresentationVerify.ts
@@ -294,6 +294,7 @@ export class PresentationVerify extends Plugins.Task<Args> {
     const fields = constraints.fields;
 
     if (constraints.limit_disclosure === "required") {
+
       for (const field of fields) {
         const paths = [...field.path];
         const optional = field.optional;
@@ -304,7 +305,9 @@ export class PresentationVerify extends Plugins.Task<Args> {
             const [path] = paths.splice(0, 1);
             try {
               this.validateField(vc, descriptorMapper, path, field);
-              return true;
+              //if field is valid, stop searching paths
+              error = undefined;
+              break;
             } catch (err) {
               //set error and continue to see if other paths succeed
               error ??= err as Error;

--- a/src/plugins/internal/dif/PresentationVerify.ts
+++ b/src/plugins/internal/dif/PresentationVerify.ts
@@ -169,11 +169,14 @@ export class PresentationVerify extends Plugins.Task<Args> {
     descriptorItem: DIF.Presentation.Submission.DescriptorItem,
     value: any,
   ): Promise<boolean> {
-
+    const isPresentation = descriptorItem.format === "jwt_vp" ? true : false;
     if (descriptorItem.path_nested) {
       const credential = await this.getCredential(ctx, descriptorItem, value);
       if (!credential) {
-        throw new Domain.PolluxError.InvalidVerifyCredentialError(value, "Invalid Presentation Credential JWS Signature");
+        throw new Domain.PolluxError.InvalidVerifyCredentialError(
+          value,
+          `Invalid ${isPresentation ? 'Verifiable Presentation' : 'Verifiable Credential'} JWS Signature`
+        );
       }
       const nestedMapper = new DescriptorPath(credential);
       const nestedValue = nestedMapper.getValue(descriptorItem.path_nested.path);
@@ -193,7 +196,10 @@ export class PresentationVerify extends Plugins.Task<Args> {
     const credential = await this.getCredential(ctx, descriptorItem, value);
     if (!credential) {
       //TODO: Improve this error, can be presentation or credential
-      throw new Domain.PolluxError.InvalidVerifyCredentialError(value, "Invalid Presentation Credential JWS Signature");
+      throw new Domain.PolluxError.InvalidVerifyCredentialError(
+        value,
+        `Invalid ${isPresentation ? 'Verifiable Presentation' : 'Verifiable Credential'} JWS Signature`
+      );
     }
 
     return credential instanceof JWTCredential ?

--- a/src/plugins/internal/dif/PresentationVerify.ts
+++ b/src/plugins/internal/dif/PresentationVerify.ts
@@ -1,5 +1,5 @@
 import * as Domain from "../../../domain";
-import { asArray, asJsonObj, expect } from "../../../utils";
+import { asArray, asJsonObj } from "../../../utils";
 import { IsCredentialRevoked } from "./IsCredentialRevoked";
 import { Payload } from "../../../domain/protocols/Payload";
 import { JWTCredential } from "../../../pollux/models/JWTVerifiableCredential";
@@ -14,7 +14,13 @@ interface Args {
   presentationRequest: DIF.Presentation.Request;
 }
 
+
 export class PresentationVerify extends Plugins.Task<Args> {
+
+  private get knownFormats() {
+    const formats: DIF.Presentation.Submission.Format[] = ["jwt_vc", "jwt_vp", "sd_jwt"];
+    return formats;
+  }
   async run(ctx: Context) {
     const presentation = this.args.presentation;
     const presentationRequest = this.args.presentationRequest;
@@ -40,173 +46,159 @@ export class PresentationVerify extends Plugins.Task<Args> {
     }
 
     const descriptorMaps = asArray(presentation_submission?.descriptor_map);
-
-    // ?? 'sdjwt' is not a DIF format
-    // const knownFormats: DIF.Presentation.Submission.Format[] = ["jwt_vc", "jwt_vp"];
-    const knownFormats = ["jwt_vc", "jwt_vp", "sdjwt"];
-    return descriptorMaps.some((x: any) => knownFormats.includes(asJsonObj(x).format));
+    return descriptorMaps.some((x: any) => this.knownFormats.includes(asJsonObj(x).format));
   }
 
   private isValidPresentationRequest(data: any): data is DIF.Presentation.Request {
     return typeof data === "object" ? true : false;
   }
 
-  private async verifySDJWT(
+  private async getCredential(
     ctx: Context,
-    presentationRequest: DIF.Presentation.Request,
-    inputDescriptors: DIF.Presentation.Definition.InputDescriptor[],
-    mapper: DescriptorPath,
-    item: DIF.Presentation.Submission.DescriptorItem
+    descriptorItem: DIF.Presentation.Submission.DescriptorItem,
+    value: any
   ) {
-    const jws = expect(
-      mapper.getValue(item.path),
-      `Invalid Submission, ${item.path} not found in submission`
-    );
+    if (descriptorItem.format === "jwt_vc" || descriptorItem.format === "jwt_vp") {
+      // for jwt_vc and jwt_vp both are JWT objects and fromJWS will load the right object
+      const credential = JWTCredential.fromJWS(value);
+      const jwtIssuer = Domain.DID.fromString(credential.issuer);
 
-    const presentation = SDJWTCredential.fromJWS(jws);
-    if ("challenge" in presentationRequest && "domain" in presentationRequest) {
-      const challenge = presentationRequest?.challenge;
+      // only the jwt_vc credentials have a subject, verifiable presentations not
+      const jwtSubject = descriptorItem.format === "jwt_vc" && credential.subject ?
+        Domain.DID.fromString(credential.subject) :
+        undefined;
 
-      if (challenge && challenge !== '') {
-        const nonce = presentation.getProperty("nonce");
-
-        if (!nonce || typeof nonce !== "string") {
-          throw new Error(`Invalid Submission, ${item.path} does not contain a nonce in its payload with a valid signature for '${challenge}'`);
-        }
-        if (nonce !== challenge) {
-          throw new Error(`Invalid Submission, ${item.path} does not contain valid signature for '${challenge}'`);
-        }
+      const valid = await ctx.JWT.verify({
+        holderDID: jwtSubject,
+        issuerDID: jwtIssuer,
+        jws: credential.id
+      });
+      if (!valid) {
+        return null;
       }
+      return credential;
+    }
+    if (descriptorItem.format === "sd_jwt") {
+      const credential = SDJWTCredential.fromJWS(value);
+      const valid = await ctx.SDJWT.verify({
+        issuerDID: credential.issuer,
+        jws: credential.id,
+        // We leave them empty, we won't be checking here
+        // but instead disclosing all the values and then validating the claims against input_descriptors
+        requiredClaimKeys: []
+      });
+      if (!valid) {
+        return null;
+      }
+      return credential;
     }
 
-
-    // [ ] https://github.com/hyperledger-identus/sdk-ts/issues/366
-    // should fail when credential invalid - requiredClaims need to be passed
-    // const requiredClaims = asArray(this.args.requiredClaims);
-    // const credentialValid = await ctx.SDJWT.verify({
-    //   issuerDID: issuer,
-    //   jws,
-    //   requiredClaimKeys: requiredClaims
-    // });
-
-    const claims = await ctx.SDJWT.reveal(
-      presentation.core.jwt?.payload ?? {},
-      presentation.core.disclosures ?? [],
+    throw new Domain.PolluxError.InvalidVerifyFormatError(
+      `Invalid Submission, ${descriptorItem.path} expected to have one of the following formats ${this.knownFormats.join(", ")} but got ${descriptorItem.format}`
     );
-    const verifiableCredentialPropsMapper = new DescriptorPath(claims);
-    const inputDescriptor = inputDescriptors.find(
-      (inputDescriptor) => inputDescriptor.id === item.id
-    );
-
-    const valid = this.validateInputDescriptor(
-      presentation.id,
-      verifiableCredentialPropsMapper,
-      inputDescriptor
-    );
-
-    return valid;
   }
 
-  private async verifyJWT(
+  private async verifyJWTClaims(
     ctx: Context,
-    presentationRequest: DIF.Presentation.Request,
     inputDescriptors: DIF.Presentation.Definition.InputDescriptor[],
-    mapper: DescriptorPath,
-    item: DIF.Presentation.Submission.DescriptorItem
+    credential: JWTCredential,
   ) {
-    const jws = expect(
-      mapper.getValue(item.path),
-      new Domain.PolluxError.InvalidVerifyFormatError(
-        `Invalid Submission, ${item.path} not found in submission`
-      )
-    );
-
-    const presentation = JWTCredential.fromJWS(jws);
-    const issuer = presentation.issuer;
-
-    // [ ] https://github.com/hyperledger-identus/sdk-ts/issues/367
-    // handle challenge, domain and nonce according to spec https://identity.foundation/presentation-exchange/
-    // const presentationDefinitionOptions = presentationRequest;
-
-    // if ("challenge" in presentationDefinitionOptions && "domain" in presentationDefinitionOptions) {
-    //   const challenge = presentationDefinitionOptions?.challenge;
-    //   if (challenge && challenge !== '') {
-    //     const nonce = presentation.getProperty('nonce');
-
-    //     if (!nonce || typeof nonce !== "string") {
-    //       throw new Domain.PolluxError.InvalidVerifyCredentialError(jws, `Invalid Submission, ${descriptorItem.path} does not contain a nonce in its payload with a valid signature for '${challenge}'`);
-    //     }
-    //     if (nonce !== challenge) {
-    //       throw new Domain.PolluxError.InvalidVerifyCredentialError(jws, `Invalid Submission, ${descriptorItem.path} does not contain valid signature for '${challenge}'`);
-    //     }
-    //   }
-    // }
-
-    // if (presentation.credentialType !== Domain.CredentialType.JWT) {
-    //   throw new Domain.PolluxError.InvalidVerifyCredentialError(jws, "Invalid JWT Credential only jwt or sdjwt is supported for jwt submission");
-    // }
-
-    const credentialValid = await ctx.JWT.verify({ issuerDID: issuer, jws });
-
-    if (!credentialValid) {
-      throw new Domain.PolluxError.InvalidVerifyCredentialError(jws, "Invalid Holder Presentation JWS Signature");
-    }
-
-    // if (descriptorItem.format !== OEA.JWT_VP) {
-    //   throw new Error("");
-    // }
-
-    const nestedPath = item.path_nested;
-
-    if (!nestedPath) {
-      throw new Domain.PolluxError.InvalidVerifyFormatError(
-        `Invalid Submission, ${item.path} of format "jwt_vp" must provide a nested_path with "jwt_vc" for JWT`
-      );
-    }
-
-    const verifiableCredentialMapper = new DescriptorPath(presentation);
-    const vc = verifiableCredentialMapper.getValue(nestedPath.path);
-
-    if (!vc) {
-      throw new Domain.PolluxError.InvalidVerifyCredentialError(jws, "Invalid Verifiable Presentation payload, cannot find vc");
-    }
-    const verifiableCredential = JWTCredential.fromJWS(vc);
     try {
-      const revocationTask = new IsCredentialRevoked({ credential: verifiableCredential });
+      const revocationTask = new IsCredentialRevoked({ credential: credential });
       const isRevoked = await ctx.run(revocationTask);
 
       if (isRevoked.data) {
-        throw new Domain.PolluxError.InvalidVerifyCredentialError(vc, "Invalid Verifiable Presentation, credential is revoked");
+        throw new Domain.PolluxError.InvalidVerifyCredentialError(credential.id, "Invalid Verifiable Presentation, credential is revoked");
       }
     } catch (err) {
       if (err instanceof Domain.PolluxError.InvalidVerifyCredentialError) {
         throw err;
       } else {
-        throw new Domain.PolluxError.InvalidVerifyCredentialError(vc, `Invalid Verifiable Presentation, could not verify if the credential is revoked, reason: ${(err as Error).message}`);
+        throw new Domain.PolluxError.InvalidVerifyCredentialError(credential.id, `Invalid Verifiable Presentation, could not verify if the credential is revoked, reason: ${(err as Error).message}`);
       }
     }
 
-    if (verifiableCredential.subject !== issuer) {
-      throw new Domain.PolluxError.InvalidVerifyCredentialError(vc, "Invalid Verifiable Presentation payload, the credential has been issued to another holder");
-    }
+    //TOOD: VC Subject must match the Holder's presentation DID, a holder should never create a presentation on a credential that was not issued to him
+    // if (verifiableCredential.subject !== issuer) {
+    //   throw new Domain.PolluxError.InvalidVerifyCredentialError(vc, "Invalid Verifiable Presentation payload, the credential has been issued to another holder");
+    // 
 
-    const verifiableCredentialValid = await ctx.JWT.verify({
-      holderDID: verifiableCredential.subject ? Domain.DID.fromString(verifiableCredential.subject) : undefined,
-      issuerDID: verifiableCredential.issuer,
-      jws: verifiableCredential.id
-    });
-    if (!verifiableCredentialValid) {
-      throw new Domain.PolluxError.InvalidVerifyCredentialError(vc, "Invalid Presentation Credential JWS Signature");
+    const mapper = new DescriptorPath(credential);
+    for (const inputDescriptor of inputDescriptors) {
+      const valid = this.validateInputDescriptor(
+        credential.id,
+        mapper,
+        inputDescriptor
+      );
+      if (!valid) {
+        return false;
+      }
     }
-    const verifiableCredentialPropsMapper = new DescriptorPath(verifiableCredential);
-    const inputDescriptor = inputDescriptors.find((inputDescriptor) => inputDescriptor.id === item.id);
+    return true;
+  }
 
-    return this.validateInputDescriptor(
-      vc,
-      verifiableCredentialPropsMapper,
-      inputDescriptor
+  private async verifySDJWTClaims(
+    ctx: Context,
+    inputDescriptors: DIF.Presentation.Definition.InputDescriptor[],
+    credential: SDJWTCredential,
+  ) {
+
+    const claims = await ctx.SDJWT.reveal(
+      credential.core.jwt?.payload ?? {},
+      credential.core.disclosures ?? [],
     );
+    const mapper = new DescriptorPath(claims);
 
+    for (const inputDescriptor of inputDescriptors) {
+      const valid = this.validateInputDescriptor(
+        credential.id,
+        mapper,
+        inputDescriptor
+      );
+      if (!valid) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private async processDescriptorItem(
+    ctx: Context,
+    inputDescriptors: DIF.Presentation.Definition.InputDescriptor[],
+    descriptorItem: DIF.Presentation.Submission.DescriptorItem,
+    value: any,
+  ): Promise<boolean> {
+
+    if (descriptorItem.path_nested) {
+      const credential = await this.getCredential(ctx, descriptorItem, value);
+      if (!credential) {
+        throw new Domain.PolluxError.InvalidVerifyCredentialError(value, "Invalid Presentation Credential JWS Signature");
+      }
+      const nestedMapper = new DescriptorPath(credential);
+      const nestedValue = nestedMapper.getValue(descriptorItem.path_nested.path);
+      if (!nestedValue) {
+        throw new Domain.PolluxError.InvalidVerifyFormatError(
+          `Invalid Submission, ${descriptorItem.path_nested.path} not found in submission`
+        );
+      }
+      return this.processDescriptorItem(
+        ctx,
+        inputDescriptors,
+        descriptorItem.path_nested,
+        nestedValue,
+      );
+    }
+
+    const credential = await this.getCredential(ctx, descriptorItem, value);
+    if (!credential) {
+      //TODO: Improve this error, can be presentation or credential
+      throw new Domain.PolluxError.InvalidVerifyCredentialError(value, "Invalid Presentation Credential JWS Signature");
+    }
+
+    return credential instanceof JWTCredential ?
+      this.verifyJWTClaims(ctx, inputDescriptors, credential) :
+      this.verifySDJWTClaims(ctx, inputDescriptors, credential);
   }
 
   private async verify(
@@ -220,32 +212,20 @@ export class PresentationVerify extends Plugins.Task<Args> {
 
     // return true if 
     for (const descriptorItem of descriptorMaps) {
-      if (descriptorItem.format === "sdjwt" as any) {
-        const valid = await this.verifySDJWT(
-          ctx,
-          presentationRequest,
-          inputDescriptors,
-          presentationSubmissionMapper,
-          descriptorItem
-        )
-        if (valid) {
-          return true;
-        }
-      } else if (descriptorItem.format === "jwt_vp") {
-        const valid = await this.verifyJWT(
-          ctx,
-          presentationRequest,
-          inputDescriptors,
-          presentationSubmissionMapper,
-          descriptorItem
-        )
-        if (valid) {
-          return true;
-        }
-      } else {
-        throw new Domain.PolluxError.InvalidVerifyFormatError(
-          `Invalid Submission, ${descriptorItem.path} expected to have format "jwt_vp"`
-        );
+      //Check descriptor format, and path or nested path
+      const inputDescriptor = inputDescriptors.find(({ id }) => id === descriptorItem.id);
+      if (!inputDescriptor) {
+        throw new Domain.PolluxError.InvalidVerifyFormatError(`Invalid Submission, undefined input descriptor`);
+      }
+      const value = presentationSubmissionMapper.getValue(descriptorItem.path);
+      const valid = await this.processDescriptorItem(
+        ctx,
+        inputDescriptors,
+        descriptorItem,
+        value
+      );
+      if (valid) {
+        return true;
       }
     }
     return false;
@@ -308,12 +288,8 @@ export class PresentationVerify extends Plugins.Task<Args> {
   private validateInputDescriptor(
     vc: any,
     descriptorMapper: DescriptorPath,
-    inputDescriptor: DIF.Presentation.Definition.InputDescriptor | undefined
+    inputDescriptor: DIF.Presentation.Definition.InputDescriptor
   ) {
-    if (!inputDescriptor) {
-      throw new Domain.PolluxError.InvalidVerifyFormatError(`Invalid Submission, undefined input descriptor`);
-    }
-
     const constraints = inputDescriptor.constraints;
     const fields = constraints.fields;
 

--- a/src/plugins/internal/dif/PresentationVerify.ts
+++ b/src/plugins/internal/dif/PresentationVerify.ts
@@ -171,8 +171,6 @@ export class PresentationVerify extends Plugins.Task<Args> {
       );
     }
 
-    const credentialType = descriptorItem.format === "jwt_vc" || descriptorItem.format === "jwt_vp" ? "jwt" : "sd_jwt";
-
     const credential = await this.getCredential(ctx, descriptorItem, value);
     if (!credential) {
       //TODO: Improve this error, can be presentation or credential

--- a/src/plugins/internal/dif/types.ts
+++ b/src/plugins/internal/dif/types.ts
@@ -2,8 +2,6 @@ export namespace DIF {
   export const PRESENTATION_REQUEST = 'dif/presentation-exchange/definitions@v1.0';
   export const PRESENTATION = 'dif/presentation-exchange/submission@v1.0';
 
-  export type formats = "jwt" | "jwt_vc" | "jwt_vp";
-
   export namespace Presentation {
     export interface Definition {
       id: string;
@@ -66,8 +64,7 @@ export namespace DIF {
     }
 
     export namespace Submission {
-      export type Format = "jwt" | "jwt_vc" | "jwt_vp";
-
+      export type Format = "sd_jwt" | "jwt_vp" | "jwt_vc";
       export interface DescriptorItem {
         id: string;
         format: Format;

--- a/src/plugins/internal/dif/types.ts
+++ b/src/plugins/internal/dif/types.ts
@@ -74,8 +74,7 @@ export namespace DIF {
     }
   }
 
-  export interface EmbedTarget {
+  export type EmbedTarget<T extends string = 'verifiablePresentation'> = {
     presentation_submission: Presentation.Submission;
-    verifiablePresentation: string[];
-  }
+  } & { [k in T]?: string[] }
 }

--- a/src/plugins/internal/oea/sdjwt/CredentialOffer.ts
+++ b/src/plugins/internal/oea/sdjwt/CredentialOffer.ts
@@ -3,6 +3,7 @@ import { PrismKeyPathIndexTask } from "../../../../edge-agent/didFunctions";
 import { Payload } from "../../../../domain/protocols/Payload";
 import { OEA } from "../types";
 import { Plugins } from "../../../../plugins";
+import { JWTPresentationPayload } from "../../../../pollux/models/JWTVerifiableCredential";
 
 interface Args {
   offer: OEA.CredentialOffer;
@@ -41,12 +42,13 @@ export class CredentialOffer extends Plugins.Task<Args> {
     // ODOT
 
 
-    const payload = {
+    const payload: JWTPresentationPayload = {
       aud: [offer.options.domain],
       nonce: offer.options.challenge,
       vp: {
         "@context": ["https://www.w3.org/2018/presentations/v1"],
         type: ["VerifiablePresentation"],
+        verifiableCredential: []
       },
     };
 

--- a/src/pollux/models/JWTVerifiableCredential.ts
+++ b/src/pollux/models/JWTVerifiableCredential.ts
@@ -8,8 +8,6 @@ import { InvalidCredentialError } from "../../domain/models/errors/Pollux";
 import {
   CredentialType,
   W3CVerifiableCredential,
-  W3CVerifiableCredentialContext,
-  W3CVerifiableCredentialType,
   W3CVerifiablePresentation,
 } from "../../domain/models/VerifiableCredential";
 
@@ -27,19 +25,21 @@ export enum JWT_VP_PROPS {
 
 export interface JWTCredentialPayload {
   [JWT.Claims.iss]: string;
+  [JWT.Claims.iat]?: number;
   [JWT.Claims.jti]?: string;
-  [JWT.Claims.nbf]: number;
-  [JWT.Claims.exp]: number;
+  [JWT.Claims.nbf]?: number;
+  [JWT.Claims.exp]?: number;
   [JWT.Claims.sub]: string;
-  [JWT.Claims.aud]?: string;
+  [JWT.Claims.aud]?: string | string[];
   [JWT_VC_PROPS.revoked]?: boolean;
   [JWT_VC_PROPS.vc]: W3CVerifiableCredential;
 }
 
 export interface JWTPresentationPayload {
   [JWT.Claims.iss]?: string;
+  [JWT.Claims.iat]?: number;
   [JWT.Claims.jti]?: string;
-  [JWT.Claims.aud]?: string;
+  [JWT.Claims.aud]?: string | string[];
   [JWT.Claims.nbf]?: number;
   [JWT.Claims.exp]?: number;
   [JWT_VP_PROPS.nonce]?: string;
@@ -404,10 +404,10 @@ export class JWTCredential
     }
     return {
       "@context": [
-        W3CVerifiableCredentialContext.credential
+        "https://www.w3.org/2018/presentations/v1"
       ],
       type: [
-        W3CVerifiableCredentialType.presentation
+        "VerifiablePresentation"
       ],
       verifiableCredential: [
         this.id
@@ -420,12 +420,8 @@ export class JWTCredential
       throw new InvalidCredentialError("Invalid payload is not VC");
     }
     return {
-      "@context": [
-        W3CVerifiableCredentialContext.credential
-      ],
-      type: [
-        W3CVerifiableCredentialType.credential
-      ],
+      "@context": ["https://www.w3.org/2018/credentials/v1"],
+      type: ["VerifiableCredential"],
       issuer: this.issuer,
       issuanceDate: this.issuanceDate,
       expirationDate: this.expirationDate,

--- a/src/pollux/models/SDJWTVerifiableCredential.ts
+++ b/src/pollux/models/SDJWTVerifiableCredential.ts
@@ -2,16 +2,14 @@ import { uuid } from "@stablelib/uuid";
 import { SDJwt, Jwt } from "@sd-jwt/core";
 import { Disclosure } from '@sd-jwt/utils';
 import {
-  Pluto,
-  StorableCredential,
-  Credential,
-  CredentialType,
-  ProvableCredential,
-  W3CVerifiablePresentation,
-  W3CVerifiableCredentialContext,
-  W3CVerifiableCredentialType,
-  PolluxError,
-  JWT
+    Pluto,
+    StorableCredential,
+    Credential,
+    CredentialType,
+    ProvableCredential,
+    W3CVerifiablePresentation,
+    PolluxError,
+    JWT
 } from "../../domain";
 import { defaultHashConfig } from "../utils/jwt/SDJWT";
 
@@ -20,11 +18,11 @@ export const SDJWTVerifiableCredentialRecoveryId = "sd+jwt+credential";
 
 
 export enum SDJWT_VP_PROPS {
-  vct = "vct",
-  revoked = "revoked",
-  _sd_alg = "_sd_alg",
-  _sd = "_sd",
-  disclosures = "disclosures"
+    vct = "vct",
+    revoked = "revoked",
+    _sd_alg = "_sd_alg",
+    _sd = "_sd",
+    disclosures = "disclosures"
 }
 
 
@@ -137,10 +135,10 @@ export class SDJWTCredential extends Credential implements ProvableCredential, S
     presentation(): W3CVerifiablePresentation {
         return {
             "@context": [
-                W3CVerifiableCredentialContext.credential
+                "https://www.w3.org/2018/presentations/v1"
             ],
             type: [
-                W3CVerifiableCredentialType.presentation
+                "VerifiablePresentation"
             ],
             verifiableCredential: [
                 this.id
@@ -169,27 +167,27 @@ export class SDJWTCredential extends Credential implements ProvableCredential, S
     }
 
     static fromJWS<E extends Record<string, any> = Record<string, any>>(
-      jws: string,
-      revoked = false,
+        jws: string,
+        revoked = false,
     ): SDJWTCredential {
-      const jwt = new Jwt(Jwt.decodeJWT(jws));
-      const disclosures = jws.split("~").slice(1).filter((k) => k);
-      const computed = disclosures.map((disclosure) => Disclosure.fromEncodeSync<E>(disclosure, {
-        alg: defaultHashConfig.hasherAlg,
-        hasher: defaultHashConfig.hasher,
-      }));
-      const loaded = new SDJwt(
-        {
-          jwt: jwt,
-          disclosures: computed
+        const jwt = new Jwt(Jwt.decodeJWT(jws));
+        const disclosures = jws.split("~").slice(1).filter((k) => k);
+        const computed = disclosures.map((disclosure) => Disclosure.fromEncodeSync<E>(disclosure, {
+            alg: defaultHashConfig.hasherAlg,
+            hasher: defaultHashConfig.hasher,
+        }));
+        const loaded = new SDJwt(
+            {
+                jwt: jwt,
+                disclosures: computed
+            }
+        );
+        const claims: Record<string, Disclosure<E>> = {};
+        for (const disclosure of computed) {
+            if (disclosure.key) {
+                claims[disclosure.key] = disclosure;
+            }
         }
-      );
-      const claims: Record<string, Disclosure<E>> = {};
-      for (const disclosure of computed) {
-        if (disclosure.key) {
-          claims[disclosure.key] = disclosure;
-        }
-      }
-      return new SDJWTCredential(loaded, [claims], revoked);
+        return new SDJWTCredential(loaded, [claims], revoked);
     }
 }

--- a/src/pollux/utils/jwt/CreateSDJWT.ts
+++ b/src/pollux/utils/jwt/CreateSDJWT.ts
@@ -1,0 +1,78 @@
+import { base58btc } from "multiformats/bases/base58";
+import * as Domain from "../../../domain";
+import { expect, notNil } from "../../../utils";
+import { Task } from "../../../utils/tasks";
+import { SdJwtVcPayload, } from "@sd-jwt/sd-jwt-vc";
+import type { DisclosureFrame } from '@sd-jwt/types';
+
+import { Plugins } from "../../../plugins";
+/**
+ * Asyncronously sign with a DID
+ *
+ * @async
+ * @param {DID} did
+ * @param payload
+ * @param header
+ * @returns {string}
+ */
+
+interface Args<T extends SdJwtVcPayload = SdJwtVcPayload> {
+    did: Domain.DID;
+    privateKey?: Domain.PrivateKey;
+    payload: T;
+    header?: Partial<Domain.JWT.Header>;
+    disclosureFrame: DisclosureFrame<T>;
+}
+
+export class CreateSDJWT<T extends SdJwtVcPayload = SdJwtVcPayload> extends Task<string, Args<T>> {
+    async run(ctx: Plugins.Context) {
+        const privateKey = await this.getPrivateKey(ctx);
+        if (!privateKey.isSignable()) {
+            throw new Error("Key is not signable");
+        }
+        const kid = await this.getSigningKid(ctx, this.args.did, privateKey);
+        const jwt = await ctx.SDJWT.sign({
+            issuerDID: this.args.did,
+            privateKey,
+            payload: this.args.payload,
+            disclosureFrame: this.args.disclosureFrame,
+            kid
+        })
+        return jwt;
+    }
+
+    private async getPrivateKey(ctx: Task.Context) {
+        if (notNil(this.args.privateKey)) {
+            return this.args.privateKey;
+        }
+
+        const keys = await ctx.Pluto.getDIDPrivateKeysByDID(this.args.did);
+        const privateKey = expect(
+            keys.find(x => x.curve === Domain.Curve.ED25519),
+            "key not found"
+        );
+
+        return privateKey;
+    }
+
+    /**
+     * try to match the privateKey with a dids verificationMethod
+     * returning the relevant key id
+     * 
+     * @param did 
+     * @param privateKey 
+     * @returns {string} kid (key identifier)
+     */
+    private async getSigningKid(ctx: Task.Context, did: Domain.DID, privateKey: Domain.PrivateKey) {
+        const pubKey = privateKey.publicKey();
+        const encoded = base58btc.encode(pubKey.to.Buffer());
+        const document = await ctx.Castor.resolveDID(did.toString());
+
+        const signingKey = document.verificationMethods.find(key => {
+            // TODO improve key identification
+            return key.publicKeyMultibase === encoded && key.id.includes("#authentication");
+        });
+
+        return signingKey?.id;
+    }
+}

--- a/src/pollux/utils/jwt/SDJWT.ts
+++ b/src/pollux/utils/jwt/SDJWT.ts
@@ -126,7 +126,7 @@ export class SDJWT extends Task.Runner {
         const signature = Buffer.from(base64url.baseDecode(signatureEncoded));
         return publicKey.verify(Buffer.from(data), signature);
       },
-      saltGenerator: this.saltGenerator
+      saltGenerator: (length: number) => this.saltGenerator(length)
     };
   }
 
@@ -161,7 +161,7 @@ export class SDJWT extends Task.Runner {
         const signatureEncoded = base64url.baseEncode(signature);
         return signatureEncoded;
       },
-      saltGenerator: this.saltGenerator
+      saltGenerator: (length: number) => this.saltGenerator(length)
     };
   }
 }

--- a/tests/fixtures/credentials/jwt.ts
+++ b/tests/fixtures/credentials/jwt.ts
@@ -1,4 +1,4 @@
-import { AttachmentDescriptor, CredentialType, W3CVerifiableCredential, W3CVerifiableCredentialContext, W3CVerifiableCredentialType } from "../../../src/domain";
+import { AttachmentDescriptor, CredentialType, W3CVerifiableCredential } from "../../../src/domain";
 import { OfferCredential } from "../../../src/edge-agent/protocols/issueCredential/OfferCredential";
 import { list } from "../dids";
 
@@ -52,19 +52,19 @@ export const credentialOfferMessage = new OfferCredential(
 );
 
 export const credentialAgent: W3CVerifiableCredential = {
-  "@context": [W3CVerifiableCredentialContext.credential],
+  "@context": ["https://www.w3.org/2018/credentials/v1"],
   credentialSubject: {
     additionalProp2: "Test3",
     id: "did:prism:beea5234af46804714d8ea8ec77b66cc7f3e815c68abb475f254cf9c30626763:CscBCsQBEmQKD2F1dGhlbnRpY2F0aW9uMBAEQk8KCXNlY3AyNTZrMRIgeSg-2OO1JdnpzUOBitzIicXdfzeAcTfWAN-YCeuCbyIaIJQ4GTI30taViwchT3e0nLXBS43B4j9jlslKo2ZldXzjElwKB21hc3RlcjAQAUJPCglzZWNwMjU2azESIHkoPtjjtSXZ6c1DgYrcyInF3X83gHE31gDfmAnrgm8iGiCUOBkyN9LWlYsHIU93tJy1wUuNweI_Y5bJSqNmZXV84w",
   },
-  type: [W3CVerifiableCredentialType.credential],
+  type: ["VerifiableCredential"],
   issuer: "did:prism:beea5234af46804714d8ea8ec77b66cc7f3e815c68abb475f254cf9c30626763:CscBCsQBEmQKD2F1dGhlbnRpY2F0aW9uMBAEQk8KCXNlY3AyNTZrMRIgeSg-2OO1JdnpzUOBitzIicXdfzeAcTfWAN-YCeuCbyIaIJQ4GTI30taViwchT3e0nLXBS43B4j9jlslKo2ZldXzjElwKB21hc3RlcjAQAUJPCglzZWNwMjU2azESIHkoPtjjtSXZ6c1DgYrcyInF3X83gHE31gDfmAnrgm8iGiCUOBkyN9LWlYsHIU93tJy1wUuNweI_Y5bJSqNmZXV84w",
   issuanceDate: new Date().toISOString(),
 };
 
 export const credential: W3CVerifiableCredential = {
-  type: [W3CVerifiableCredentialType.credential],
-  "@context": [W3CVerifiableCredentialContext.credential],
+  type: ["VerifiableCredential"],
+  "@context": ["https://www.w3.org/2018/credentials/v1"],
   credentialSubject: {
     additionalProp2: 'Test3',
     id: 'did:prism:beea5234af46804714d8ea8ec77b66cc7f3e815c68abb475f254cf9c30626763:CscBCsQBEmQKD2F1dGhlbnRpY2F0aW9uMBAEQk8KCXNlY3AyNTZrMRIgeSg-2OO1JdnpzUOBitzIicXdfzeAcTfWAN-YCeuCbyIaIJQ4GTI30taViwchT3e0nLXBS43B4j9jlslKo2ZldXzjElwKB21hc3RlcjAQAUJPCglzZWNwMjU2azESIHkoPtjjtSXZ6c1DgYrcyInF3X83gHE31gDfmAnrgm8iGiCUOBkyN9LWlYsHIU93tJy1wUuNweI_Y5bJSqNmZXV84w'

--- a/tests/plugins/dif/PresentationRequest.test.ts
+++ b/tests/plugins/dif/PresentationRequest.test.ts
@@ -148,7 +148,7 @@ describe("Plugins - DIF", () => {
       expect(descriptorMap).toHaveLength(1);
       expect(descriptorMap[0]).toEqual({
         id: inputDescriptor.id,
-        format: "sdjwt",
+        format: "sd_jwt",
         path: "$.verifiablePresentation[0]",
       });
     });

--- a/tests/plugins/dif/PresentationVerify.test.ts
+++ b/tests/plugins/dif/PresentationVerify.test.ts
@@ -6,9 +6,10 @@ import { Task } from '../../../src/utils';
 import { Apollo, Castor } from '../../../src';
 import { JWT, SDJWT } from "../../../src/pollux/utils/jwt";
 import { PresentationVerify } from '../../../src/plugins/internal/dif/PresentationVerify';
-import { Curve, KeyTypes, W3CVerifiableCredentialContext, W3CVerifiableCredentialType } from '../../../src/domain';
+import { Curve, KeyTypes } from '../../../src/domain';
 import { CreateSDJWT } from '../../../src/pollux/utils/jwt/CreateSDJWT';
 import { DIFModule } from '../../../src/plugins/internal/dif/module';
+import { JWTCredentialPayload, JWTPresentationPayload } from '../../../src/pollux/models/JWTVerifiableCredential';
 
 describe("Plugins - DIF", () => {
   let ctx: Task.Context<{
@@ -33,33 +34,6 @@ describe("Plugins - DIF", () => {
 
   describe("PresentationVerify", () => {
     describe("JWT", () => {
-      const issuerDID = "did:prism:0858c30daf6d0cc3e0b1ae31b7cb212f4446a6e0f47a5926b3ba7dc64986157b:CmEKXxJdCghtYXN0ZXItMBABQk8KCXNlY3AyNTZrMRIgM3HxlER-HNHG59NAGoJJ7OdA5XlQAbOU5JqPGmnkZiQaIFYj9QUSo_xiemYiLHlBBkwHjZZKR1FjSA2OlgKI9iC9";
-      const issuerPK = {
-        curve: "Secp256k1",
-        hex: "ad29fa414bdc84737fba87743e7b9f876e278a18d0036ab782042e0c6e7a4672"
-      };
-      const holderDID = "did:prism:38e78e4dd9711c49a1fb533b0247c5a26516e38e99a259cd21ff5b84097533d6:CmEKXxJdCghtYXN0ZXItMBABQk8KCXNlY3AyNTZrMRIgp6Bi0cCJRnOQQxeL5RXjW7v1zKJrJQ7Wcoxy5OGV3HkaID3gsu86_sFD09sWeR7O8aQCVeludTW5aYSPoPiQEgBi";
-      const holderPK = {
-        curve: "Secp256k1",
-        hex: "e7e232848313a57c5161a9d6e1813db133ae9f1baffb3c5e82dba220746bf18a"
-      };
-      const jwt = "eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJpYXQiOjE3MzY1MTEzNzcsImV4cCI6MTczOTE4OTc3NzYyNiwiaXNzIjoiZGlkOnByaXNtOjA4NThjMzBkYWY2ZDBjYzNlMGIxYWUzMWI3Y2IyMTJmNDQ0NmE2ZTBmNDdhNTkyNmIzYmE3ZGM2NDk4NjE1N2I6Q21FS1h4SmRDZ2h0WVhOMFpYSXRNQkFCUWs4S0NYTmxZM0F5TlRack1SSWdNM0h4bEVSLUhOSEc1OU5BR29KSjdPZEE1WGxRQWJPVTVKcVBHbW5rWmlRYUlGWWo5UVVTb194aWVtWWlMSGxCQmt3SGpaWktSMUZqU0EyT2xnS0k5aUM5IiwibmJmIjoxNzM2NTExMzc3NjI2LCJzdWIiOiJkaWQ6cHJpc206MzhlNzhlNGRkOTcxMWM0OWExZmI1MzNiMDI0N2M1YTI2NTE2ZTM4ZTk5YTI1OWNkMjFmZjViODQwOTc1MzNkNjpDbUVLWHhKZENnaHRZWE4wWlhJdE1CQUJRazhLQ1hObFkzQXlOVFpyTVJJZ3A2QmkwY0NKUm5PUVF4ZUw1UlhqVzd2MXpLSnJKUTdXY294eTVPR1YzSGthSUQzZ3N1ODZfc0ZEMDlzV2VSN084YVFDVmVsdWRUVzVhWVNQb1BpUUVnQmkiLCJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIl0sImlzc3VlciI6ImRpZDpwcmlzbTowODU4YzMwZGFmNmQwY2MzZTBiMWFlMzFiN2NiMjEyZjQ0NDZhNmUwZjQ3YTU5MjZiM2JhN2RjNjQ5ODYxNTdiOkNtRUtYeEpkQ2dodFlYTjBaWEl0TUJBQlFrOEtDWE5sWTNBeU5UWnJNUklnTTNIeGxFUi1ITkhHNTlOQUdvSko3T2RBNVhsUUFiT1U1SnFQR21ua1ppUWFJRllqOVFVU29feGllbVlpTEhsQkJrd0hqWlpLUjFGalNBMk9sZ0tJOWlDOSIsImlzc3VhbmNlRGF0ZSI6IjIwMjUtMDEtMTBUMTI6MTY6MTcuNjI2WiIsImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImNvdXJzZSI6IklkZW50dXMgVHJhaW5pbmcgY291cnNlIENlcnRpZmljYXRpb24gMjAyNCJ9fX0.SGpkR7YG-yYyNxZ4w_UF1yueu2gf73R-BktKX_mPZth2s4pOdr5NFuz3M6faFBZKTbD5ydGHFE4bbWLk09vB2g";
-      const payload = {
-        iss: issuerDID,
-        nbf: 1736511377626,
-        exp: 1739189777626,
-        sub: holderDID,
-        vc: {
-          "@context": ["https://www.w3.org/2018/credentials/v1"],
-          type: ["VerifiableCredential"],
-          issuer: issuerDID,
-          issuanceDate: "2025-01-10T12:16:17.626Z",
-          credentialSubject: {
-            course: "Identus Training course Certification 2024",
-          },
-        },
-      };
-
       const presentation: DIF.EmbedTarget = {
         presentation_submission: {
           id: "0b17b996-7d52-4b2a-81fd-e6ffcd6dd188",
@@ -245,11 +219,837 @@ describe("Plugins - DIF", () => {
 
           expect(result.data).toBe(false);
         });
+
+        test("Should verify false when presentation is valid using jwt_vc and jwt_vp with nested paths but presentation signature is invalid", async () => {
+          const issuerSeed = ctx.Apollo.createRandomSeed().seed;
+          const holderSeed = ctx.Apollo.createRandomSeed().seed;
+
+          const issuerMasterSK = ctx.Apollo.createPrivateKey({
+            type: KeyTypes.EC,
+            curve: Curve.SECP256K1,
+            seed: Buffer.from(issuerSeed.value).toString("hex"),
+          });
+          const issuerAuthenticationSK = ctx.Apollo.createPrivateKey({
+            type: KeyTypes.EC,
+            curve: Curve.ED25519,
+            seed: Buffer.from(issuerSeed.value).toString("hex"),
+          });
+
+          const holderMasterSK = ctx.Apollo.createPrivateKey({
+            type: KeyTypes.EC,
+            curve: Curve.SECP256K1,
+            seed: Buffer.from(holderSeed.value).toString("hex"),
+          });
+          const holderAuthenticationSK = ctx.Apollo.createPrivateKey({
+            type: KeyTypes.EC,
+            curve: Curve.ED25519,
+            seed: Buffer.from(holderSeed.value).toString("hex"),
+          });
+
+          const issuerDID = await ctx.Castor.createPrismDID(
+            issuerMasterSK.publicKey(),
+            [],
+            [
+              issuerAuthenticationSK.publicKey()
+            ]
+          );
+
+          const holderDID = await ctx.Castor.createPrismDID(
+            holderMasterSK.publicKey(),
+            [],
+            [
+              holderAuthenticationSK.publicKey()
+            ]
+          );
+
+          const currentDate = new Date();
+          const nextMonthDate = new Date(currentDate);
+          nextMonthDate.setMonth(currentDate.getMonth() + 1);
+          const issuanceDate = currentDate.getTime();
+          const expirationDate = nextMonthDate.getTime();
+
+          const vcPayload: JWTCredentialPayload = {
+            iss: issuerDID.toString(),
+            nbf: issuanceDate,
+            exp: expirationDate,
+            sub: holderDID.toString(),
+            vc: {
+              "@context": ["https://www.w3.org/2018/credentials/v1"],
+              type: ["VerifiableCredential"],
+              issuer: issuerDID.toString(),
+              issuanceDate: new Date(issuanceDate).toISOString(),
+              credentialSubject: {
+                firstname: "John Doe",
+                email: 'demo@email.com',
+                course: "Identus Training course Certification 2024",
+              },
+            },
+          };
+
+          const jwt = await ctx.JWT.signWithDID(issuerDID, vcPayload, undefined, issuerAuthenticationSK);
+
+          const vpPayload: JWTPresentationPayload = {
+            iss: holderDID.toString(),
+            nbf: issuanceDate,
+            exp: expirationDate,
+            vp: {
+              "@context": ["https://www.w3.org/2018/presentations/v1"],
+              type: ["VerifiablePresentation"],
+              verifiableCredential: [
+                jwt
+              ]
+            }
+          };
+          const presentationJWT = await ctx.JWT.signWithDID(holderDID, vpPayload, undefined, issuerAuthenticationSK)
+
+
+          const presentation: DIF.EmbedTarget = {
+            presentation_submission: {
+              id: "0b17b996-7d52-4b2a-81fd-e6ffcd6dd188",
+              definition_id: "ba7814d4-4bdf-42a5-a3f9-a2e86419e6c4",
+              descriptor_map: [{
+                id: "9e50eb6b-e7fc-46a8-bd91-7d53ac4adc53",
+                format: "jwt_vp",
+                path: "$.verifiablePresentation[0]",
+                path_nested: {
+                  id: "9e50eb6b-e7fc-46a8-bd91-7d53ac4adc53",
+                  format: "jwt_vc",
+                  path: "$.vp.verifiableCredential[0]",
+                },
+              },
+              ],
+            },
+            verifiablePresentation: [
+              presentationJWT
+            ]
+          };
+
+          const presentationRequest: DIF.Presentation.Request = {
+            presentation_definition: {
+              id: "ba7814d4-4bdf-42a5-a3f9-a2e86419e6c4",
+              input_descriptors: [
+                {
+                  id: "9e50eb6b-e7fc-46a8-bd91-7d53ac4adc53",
+                  name: "Presentation",
+                  purpose: "Verifying Credentials",
+                  constraints: {
+                    fields: [
+                      {
+                        path: [
+                          "$.vc.credentialSubject.course",
+                          "$.credentialSubject.course",
+                          "$.course",
+                        ],
+                        id: "c9c60d68-a25d-4ab0-8968-8d270ad95590",
+                        optional: false,
+                        filter: {
+                          type: "string",
+                          pattern: "Identus Training course Certification 2024",
+                        },
+                        name: "course",
+                      },
+                      {
+                        path: [
+                          "$.vc.issuer",
+                          "$.issuer",
+                          "$.iss",
+                          "$.vc.iss",
+                        ],
+                        id: "6a6fa378-d701-43e7-81d5-ee1cd80c585e",
+                        optional: false,
+                        name: "issuer",
+                        filter: {
+                          type: "string",
+                          pattern: "did:prism:0858c30daf6d0cc3e0b1ae31b7cb212f4446a6e0f47a5926b3ba7dc64986157b:CmEKXxJdCghtYXN0ZXItMBABQk8KCXNlY3AyNTZrMRIgM3HxlER-HNHG59NAGoJJ7OdA5XlQAbOU5JqPGmnkZiQaIFYj9QUSo_xiemYiLHlBBkwHjZZKR1FjSA2OlgKI9iC9",
+                        },
+                      },
+                    ],
+                    limit_disclosure: "required",
+                  },
+                  format: {
+                    jwt: {
+                      alg: [
+                        "ES256K",
+                      ],
+                    },
+                  },
+                },
+              ],
+              format: {
+                jwt: {
+                  alg: [
+                    "ES256K",
+                  ],
+                },
+              },
+            },
+            options: {
+              challenge: "sign this",
+              domain: "N/A",
+            },
+          };
+
+
+
+
+
+          const sut = new PresentationVerify({ presentation, presentationRequest, });
+          const result = ctx.run(sut);
+
+          await expect(result).rejects.toThrow(
+            `Verification failed for credential (eyJhbGciOi...): reason -> Invalid Verifiable Presentation JWS Signature`
+          );
+        })
+
+
+
+        test("Should verify false when presentation is valid using jwt_vc and jwt_vp with nested paths but credential signature is invalid", async () => {
+          const issuerSeed = ctx.Apollo.createRandomSeed().seed;
+          const holderSeed = ctx.Apollo.createRandomSeed().seed;
+
+          const issuerMasterSK = ctx.Apollo.createPrivateKey({
+            type: KeyTypes.EC,
+            curve: Curve.SECP256K1,
+            seed: Buffer.from(issuerSeed.value).toString("hex"),
+          });
+          const issuerAuthenticationSK = ctx.Apollo.createPrivateKey({
+            type: KeyTypes.EC,
+            curve: Curve.ED25519,
+            seed: Buffer.from(issuerSeed.value).toString("hex"),
+          });
+
+          const holderMasterSK = ctx.Apollo.createPrivateKey({
+            type: KeyTypes.EC,
+            curve: Curve.SECP256K1,
+            seed: Buffer.from(holderSeed.value).toString("hex"),
+          });
+          const holderAuthenticationSK = ctx.Apollo.createPrivateKey({
+            type: KeyTypes.EC,
+            curve: Curve.ED25519,
+            seed: Buffer.from(holderSeed.value).toString("hex"),
+          });
+
+          const issuerDID = await ctx.Castor.createPrismDID(
+            issuerMasterSK.publicKey(),
+            [],
+            [
+              issuerAuthenticationSK.publicKey()
+            ]
+          );
+
+          const holderDID = await ctx.Castor.createPrismDID(
+            holderMasterSK.publicKey(),
+            [],
+            [
+              holderAuthenticationSK.publicKey()
+            ]
+          );
+
+          const currentDate = new Date();
+          const nextMonthDate = new Date(currentDate);
+          nextMonthDate.setMonth(currentDate.getMonth() + 1);
+          const issuanceDate = currentDate.getTime();
+          const expirationDate = nextMonthDate.getTime();
+
+          const vcPayload: JWTCredentialPayload = {
+            iss: issuerDID.toString(),
+            nbf: issuanceDate,
+            exp: expirationDate,
+            sub: holderDID.toString(),
+            vc: {
+              "@context": ["https://www.w3.org/2018/credentials/v1"],
+              type: ["VerifiableCredential"],
+              issuer: issuerDID.toString(),
+              issuanceDate: new Date(issuanceDate).toISOString(),
+              credentialSubject: {
+                firstname: "John Doe",
+                email: 'demo@email.com',
+                course: "Identus Training course Certification 2024",
+              },
+            },
+          };
+
+          const jwt = await ctx.JWT.signWithDID(issuerDID, vcPayload, undefined, holderAuthenticationSK);
+
+          const vpPayload: JWTPresentationPayload = {
+            iss: holderDID.toString(),
+            nbf: issuanceDate,
+            exp: expirationDate,
+            vp: {
+              "@context": ["https://www.w3.org/2018/presentations/v1"],
+              type: ["VerifiablePresentation"],
+              verifiableCredential: [
+                jwt
+              ]
+            }
+          };
+          const presentationJWT = await ctx.JWT.signWithDID(holderDID, vpPayload, undefined, holderMasterSK)
+
+
+          const presentation: DIF.EmbedTarget = {
+            presentation_submission: {
+              id: "0b17b996-7d52-4b2a-81fd-e6ffcd6dd188",
+              definition_id: "ba7814d4-4bdf-42a5-a3f9-a2e86419e6c4",
+              descriptor_map: [{
+                id: "9e50eb6b-e7fc-46a8-bd91-7d53ac4adc53",
+                format: "jwt_vp",
+                path: "$.verifiablePresentation[0]",
+                path_nested: {
+                  id: "9e50eb6b-e7fc-46a8-bd91-7d53ac4adc53",
+                  format: "jwt_vc",
+                  path: "$.vp.verifiableCredential[0]",
+                },
+              },
+              ],
+            },
+            verifiablePresentation: [
+              presentationJWT
+            ]
+          };
+
+          const presentationRequest: DIF.Presentation.Request = {
+            presentation_definition: {
+              id: "ba7814d4-4bdf-42a5-a3f9-a2e86419e6c4",
+              input_descriptors: [
+                {
+                  id: "9e50eb6b-e7fc-46a8-bd91-7d53ac4adc53",
+                  name: "Presentation",
+                  purpose: "Verifying Credentials",
+                  constraints: {
+                    fields: [
+                      {
+                        path: [
+                          "$.vc.credentialSubject.course",
+                          "$.credentialSubject.course",
+                          "$.course",
+                        ],
+                        id: "c9c60d68-a25d-4ab0-8968-8d270ad95590",
+                        optional: false,
+                        filter: {
+                          type: "string",
+                          pattern: "Identus Training course Certification 2024",
+                        },
+                        name: "course",
+                      },
+                      {
+                        path: [
+                          "$.vc.issuer",
+                          "$.issuer",
+                          "$.iss",
+                          "$.vc.iss",
+                        ],
+                        id: "6a6fa378-d701-43e7-81d5-ee1cd80c585e",
+                        optional: false,
+                        name: "issuer",
+                        filter: {
+                          type: "string",
+                          pattern: "did:prism:0858c30daf6d0cc3e0b1ae31b7cb212f4446a6e0f47a5926b3ba7dc64986157b:CmEKXxJdCghtYXN0ZXItMBABQk8KCXNlY3AyNTZrMRIgM3HxlER-HNHG59NAGoJJ7OdA5XlQAbOU5JqPGmnkZiQaIFYj9QUSo_xiemYiLHlBBkwHjZZKR1FjSA2OlgKI9iC9",
+                        },
+                      },
+                    ],
+                    limit_disclosure: "required",
+                  },
+                  format: {
+                    jwt: {
+                      alg: [
+                        "ES256K",
+                      ],
+                    },
+                  },
+                },
+              ],
+              format: {
+                jwt: {
+                  alg: [
+                    "ES256K",
+                  ],
+                },
+              },
+            },
+            options: {
+              challenge: "sign this",
+              domain: "N/A",
+            },
+          };
+
+          const sut = new PresentationVerify({ presentation, presentationRequest, });
+          const result = ctx.run(sut);
+
+          await expect(result).rejects.toThrow(
+            `Verification failed for credential (eyJhbGciOi...): reason -> Invalid Verifiable Credential JWS Signature`
+          );
+        })
+
+        test("Should verify true when presentation is valid using jwt_vc and jwt_vp with nested paths", async () => {
+          const sut = new PresentationVerify({ presentation, presentationRequest, });
+          const result = await ctx.run(sut);
+
+          expect(result.data).toBe(true);
+        })
+
+        test("Should verify true when the presentation is valid,using jwt_vc only", async () => {
+
+          const issuerSeed = ctx.Apollo.createRandomSeed().seed;
+          const holderSeed = ctx.Apollo.createRandomSeed().seed;
+
+          const issuerMasterSK = ctx.Apollo.createPrivateKey({
+            type: KeyTypes.EC,
+            curve: Curve.SECP256K1,
+            seed: Buffer.from(issuerSeed.value).toString("hex"),
+          });
+          const issuerAuthenticationSK = ctx.Apollo.createPrivateKey({
+            type: KeyTypes.EC,
+            curve: Curve.ED25519,
+            seed: Buffer.from(issuerSeed.value).toString("hex"),
+          });
+
+          const holderMasterSK = ctx.Apollo.createPrivateKey({
+            type: KeyTypes.EC,
+            curve: Curve.SECP256K1,
+            seed: Buffer.from(holderSeed.value).toString("hex"),
+          });
+          const holderAuthenticationSK = ctx.Apollo.createPrivateKey({
+            type: KeyTypes.EC,
+            curve: Curve.ED25519,
+            seed: Buffer.from(holderSeed.value).toString("hex"),
+          });
+
+          const issuerDID = await ctx.Castor.createPrismDID(
+            issuerMasterSK.publicKey(),
+            [],
+            [
+              issuerAuthenticationSK.publicKey()
+            ]
+          );
+
+          const holderDID = await ctx.Castor.createPrismDID(
+            holderMasterSK.publicKey(),
+            [],
+            [
+              holderAuthenticationSK.publicKey()
+            ]
+          );
+
+          const presentationRequest: DIF.Presentation.Request = {
+            presentation_definition: {
+              id: "ba7814d4-4bdf-42a5-a3f9-a2e86419e6c4",
+              input_descriptors: [
+                {
+                  id: "9e50eb6b-e7fc-46a8-bd91-7d53ac4adc53",
+                  name: "Presentation",
+                  purpose: "Verifying Credentials",
+                  constraints: {
+                    fields: [
+                      {
+                        path: [
+                          "$.vc.credentialSubject.course",
+                          "$.credentialSubject.course",
+                          "$.course",
+                        ],
+                        id: "c9c60d68-a25d-4ab0-8968-8d270ad95590",
+                        optional: false,
+                        filter: {
+                          type: "string",
+                          pattern: "Identus Training course Certification 2024",
+                        },
+                        name: "course",
+                      },
+                      {
+                        path: [
+                          "$.vc.issuer",
+                          "$.issuer",
+                          "$.iss",
+                          "$.vc.iss",
+                        ],
+                        id: "6a6fa378-d701-43e7-81d5-ee1cd80c585e",
+                        optional: false,
+                        name: "issuer",
+                        filter: {
+                          type: "string",
+                          pattern: issuerDID.toString(),
+                        },
+                      },
+                    ],
+                    limit_disclosure: "required",
+                  },
+                  format: {
+                    jwt: {
+                      alg: [
+                        "ES256K",
+                      ],
+                    },
+                  },
+                },
+              ],
+              format: {
+                jwt: {
+                  alg: [
+                    "ES256K",
+                  ],
+                },
+              },
+            },
+            options: {
+              challenge: "sign this",
+              domain: "N/A",
+            },
+          };
+
+          const currentDate = new Date();
+          const nextMonthDate = new Date(currentDate);
+          nextMonthDate.setMonth(currentDate.getMonth() + 1);
+          const issuanceDate = currentDate.getTime();
+          const expirationDate = nextMonthDate.getTime();
+
+          const payload = {
+            iss: issuerDID.toString(),
+            nbf: issuanceDate,
+            exp: expirationDate,
+            sub: holderDID.toString(),
+            vc: {
+              "@context": ["https://www.w3.org/2018/credentials/v1"],
+              type: ["VerifiableCredential"],
+              issuer: issuerDID.toString(),
+              issuanceDate: new Date(issuanceDate).toISOString(),
+              credentialSubject: {
+                firstname: "John Doe",
+                email: 'demo@email.com',
+                course: "Identus Training course Certification 2024",
+              },
+            },
+          };
+
+          const jwt = await ctx.JWT.signWithDID(issuerDID, payload, undefined, issuerAuthenticationSK);
+
+          const presentation: DIF.EmbedTarget<'verifiableCredential'> = {
+            presentation_submission: {
+              id: "f28b346e-c20e-4651-8c24-7f41a576cf26",
+              definition_id: "acd86273-5017-4980-a9be-dab6c725c811",
+              descriptor_map: [
+                {
+                  id: "9e50eb6b-e7fc-46a8-bd91-7d53ac4adc53",
+                  format: "jwt_vc",
+                  path: "$.verifiableCredential[0]",
+                },
+              ],
+            },
+            verifiableCredential: [
+              jwt,
+            ],
+          };
+
+
+          const sut = new PresentationVerify({ presentation, presentationRequest, });
+          const result = await ctx.run(sut);
+
+          expect(result.data).toBe(true);
+        });
+
+        test("Should verify false when the presentation is invalid, wrong signature,using jwt_vc only", async () => {
+
+          const issuerSeed = ctx.Apollo.createRandomSeed().seed;
+          const holderSeed = ctx.Apollo.createRandomSeed().seed;
+
+          const issuerMasterSK = ctx.Apollo.createPrivateKey({
+            type: KeyTypes.EC,
+            curve: Curve.SECP256K1,
+            seed: Buffer.from(issuerSeed.value).toString("hex"),
+          });
+
+
+          const holderMasterSK = ctx.Apollo.createPrivateKey({
+            type: KeyTypes.EC,
+            curve: Curve.SECP256K1,
+            seed: Buffer.from(holderSeed.value).toString("hex"),
+          });
+
+          const issuerDID = await ctx.Castor.createPrismDID(issuerMasterSK.publicKey(), [], []);
+          const holderDID = await ctx.Castor.createPrismDID(holderMasterSK.publicKey(), [], []);
+
+          const presentationRequest: DIF.Presentation.Request = {
+            presentation_definition: {
+              id: "ba7814d4-4bdf-42a5-a3f9-a2e86419e6c4",
+              input_descriptors: [
+                {
+                  id: "9e50eb6b-e7fc-46a8-bd91-7d53ac4adc53",
+                  name: "Presentation",
+                  purpose: "Verifying Credentials",
+                  constraints: {
+                    fields: [
+                      {
+                        path: [
+                          "$.vc.credentialSubject.course",
+                          "$.credentialSubject.course",
+                          "$.course",
+                        ],
+                        id: "c9c60d68-a25d-4ab0-8968-8d270ad95590",
+                        optional: false,
+                        filter: {
+                          type: "string",
+                          pattern: "Identus Training course Certification 2024",
+                        },
+                        name: "course",
+                      },
+                      {
+                        path: [
+                          "$.vc.issuer",
+                          "$.issuer",
+                          "$.iss",
+                          "$.vc.iss",
+                        ],
+                        id: "6a6fa378-d701-43e7-81d5-ee1cd80c585e",
+                        optional: false,
+                        name: "issuer",
+                        filter: {
+                          type: "string",
+                          pattern: issuerDID.toString(),
+                        },
+                      },
+                    ],
+                    limit_disclosure: "required",
+                  },
+                  format: {
+                    jwt: {
+                      alg: [
+                        "ES256K",
+                      ],
+                    },
+                  },
+                },
+              ],
+              format: {
+                jwt: {
+                  alg: [
+                    "ES256K",
+                  ],
+                },
+              },
+            },
+            options: {
+              challenge: "sign this",
+              domain: "N/A",
+            },
+          };
+
+          const currentDate = new Date();
+          const nextMonthDate = new Date(currentDate);
+          nextMonthDate.setMonth(currentDate.getMonth() + 1);
+          const issuanceDate = currentDate.getTime();
+          const expirationDate = nextMonthDate.getTime();
+
+          const payload = {
+            iss: issuerDID.toString(),
+            nbf: issuanceDate,
+            exp: expirationDate,
+            sub: issuerDID.toString(),
+            vc: {
+              "@context": ["https://www.w3.org/2018/credentials/v1"],
+              type: ["VerifiableCredential"],
+              issuer: issuerDID.toString(),
+              issuanceDate: new Date(issuanceDate).toISOString(),
+              credentialSubject: {
+                firstname: "John Doe",
+                email: 'demo@email.com',
+                course: "Identus Training course Certification 2024",
+              },
+            },
+          };
+
+          const jwt = await ctx.JWT.signWithDID(issuerDID, payload, undefined, holderMasterSK);
+
+          const presentation: DIF.EmbedTarget<'verifiableCredential'> = {
+            presentation_submission: {
+              id: "f28b346e-c20e-4651-8c24-7f41a576cf26",
+              definition_id: "acd86273-5017-4980-a9be-dab6c725c811",
+              descriptor_map: [
+                {
+                  id: "9e50eb6b-e7fc-46a8-bd91-7d53ac4adc53",
+                  format: "jwt_vc",
+                  path: "$.verifiableCredential[0]",
+                },
+              ],
+            },
+            verifiableCredential: [
+              jwt,
+            ],
+          };
+
+
+          const sut = new PresentationVerify({ presentation, presentationRequest, });
+          const result = ctx.run(sut);
+
+          await expect(result).rejects.toThrow(
+            `Verification failed for credential (eyJhbGciOi...): reason -> Invalid Verifiable Credential JWS Signature`
+          );
+
+        });
+
+        test("Should verify false when the presentation is invalid wrong issuer did,using jwt_vc only", async () => {
+
+          const issuerSeed = ctx.Apollo.createRandomSeed().seed;
+          const holderSeed = ctx.Apollo.createRandomSeed().seed;
+
+          const issuerMasterSK = ctx.Apollo.createPrivateKey({
+            type: KeyTypes.EC,
+            curve: Curve.SECP256K1,
+            seed: Buffer.from(issuerSeed.value).toString("hex"),
+          });
+          const issuerAuthenticationSK = ctx.Apollo.createPrivateKey({
+            type: KeyTypes.EC,
+            curve: Curve.ED25519,
+            seed: Buffer.from(issuerSeed.value).toString("hex"),
+          });
+
+          const holderMasterSK = ctx.Apollo.createPrivateKey({
+            type: KeyTypes.EC,
+            curve: Curve.SECP256K1,
+            seed: Buffer.from(holderSeed.value).toString("hex"),
+          });
+          const holderAuthenticationSK = ctx.Apollo.createPrivateKey({
+            type: KeyTypes.EC,
+            curve: Curve.ED25519,
+            seed: Buffer.from(holderSeed.value).toString("hex"),
+          });
+
+          const issuerDID = await ctx.Castor.createPrismDID(
+            issuerMasterSK.publicKey(),
+            [],
+            [
+              issuerAuthenticationSK.publicKey()
+            ]
+          );
+
+          const holderDID = await ctx.Castor.createPrismDID(
+            holderMasterSK.publicKey(),
+            [],
+            [
+              holderAuthenticationSK.publicKey()
+            ]
+          );
+
+          const presentationRequest: DIF.Presentation.Request = {
+            presentation_definition: {
+              id: "ba7814d4-4bdf-42a5-a3f9-a2e86419e6c4",
+              input_descriptors: [
+                {
+                  id: "9e50eb6b-e7fc-46a8-bd91-7d53ac4adc53",
+                  name: "Presentation",
+                  purpose: "Verifying Credentials",
+                  constraints: {
+                    fields: [
+                      {
+                        path: [
+                          "$.vc.credentialSubject.course",
+                          "$.credentialSubject.course",
+                          "$.course",
+                        ],
+                        id: "c9c60d68-a25d-4ab0-8968-8d270ad95590",
+                        optional: false,
+                        filter: {
+                          type: "string",
+                          pattern: "Identus Training course Certification 2024",
+                        },
+                        name: "course",
+                      },
+                      {
+                        path: [
+                          "$.vc.issuer",
+                          "$.issuer",
+                          "$.iss",
+                          "$.vc.iss",
+                        ],
+                        id: "6a6fa378-d701-43e7-81d5-ee1cd80c585e",
+                        optional: false,
+                        name: "issuer",
+                        filter: {
+                          type: "string",
+                          pattern: holderDID.toString(),
+                        },
+                      },
+                    ],
+                    limit_disclosure: "required",
+                  },
+                  format: {
+                    jwt: {
+                      alg: [
+                        "ES256K",
+                      ],
+                    },
+                  },
+                },
+              ],
+              format: {
+                jwt: {
+                  alg: [
+                    "ES256K",
+                  ],
+                },
+              },
+            },
+            options: {
+              challenge: "sign this",
+              domain: "N/A",
+            },
+          };
+
+          const currentDate = new Date();
+          const nextMonthDate = new Date(currentDate);
+          nextMonthDate.setMonth(currentDate.getMonth() + 1);
+          const issuanceDate = currentDate.getTime();
+          const expirationDate = nextMonthDate.getTime();
+
+          const payload = {
+            iss: issuerDID.toString(),
+            nbf: issuanceDate,
+            exp: expirationDate,
+            sub: holderDID.toString(),
+            vc: {
+              "@context": ["https://www.w3.org/2018/credentials/v1"],
+              type: ["VerifiableCredential"],
+              issuer: issuerDID.toString(),
+              issuanceDate: new Date(issuanceDate).toISOString(),
+              credentialSubject: {
+                firstname: "John Doe",
+                email: 'demo@email.com',
+                course: "Identus Training course Certification 2024",
+              },
+            },
+          };
+
+          const jwt = await ctx.JWT.signWithDID(issuerDID, payload, undefined, issuerAuthenticationSK);
+
+          const presentation: DIF.EmbedTarget<'verifiableCredential'> = {
+            presentation_submission: {
+              id: "f28b346e-c20e-4651-8c24-7f41a576cf26",
+              definition_id: "acd86273-5017-4980-a9be-dab6c725c811",
+              descriptor_map: [
+                {
+                  id: "9e50eb6b-e7fc-46a8-bd91-7d53ac4adc53",
+                  format: "jwt_vc",
+                  path: "$.verifiableCredential[0]",
+                },
+              ],
+            },
+            verifiableCredential: [
+              jwt,
+            ],
+          };
+
+
+          const sut = new PresentationVerify({ presentation, presentationRequest, });
+          const result = ctx.run(sut);
+
+          await expect(result).rejects.toThrow(
+            `Verification failed for credential (eyJraWQiOi...): reason -> Invalid Claim: Expected the $.vc.issuer field to be "${holderDID.toString()}" but got "${issuerDID.toString()}"`
+          );
+
+        });
       });
     });
   });
 
   describe("SDJWT", () => {
+
     const presentation: DIF.EmbedTarget = {
       presentation_submission: {
         id: "f28b346e-c20e-4651-8c24-7f41a576cf26",
@@ -257,7 +1057,7 @@ describe("Plugins - DIF", () => {
         descriptor_map: [
           {
             id: "c3fd00a4-129d-49dc-a640-d84ad32826d9",
-            format: "sd_jwt" as any,
+            format: "sd_jwt",
             path: "$.verifiablePresentation[0]",
           },
         ],
@@ -424,7 +1224,7 @@ describe("Plugins - DIF", () => {
       const holderMasterSK = ctx.Apollo.createPrivateKey({
         type: KeyTypes.EC,
         curve: Curve.SECP256K1,
-        seed: Buffer.from(issuerSeed.value).toString("hex"),
+        seed: Buffer.from(holderSeed.value).toString("hex"),
       });
       const holderAuthenticationSK = ctx.Apollo.createPrivateKey({
         type: KeyTypes.EC,
@@ -460,8 +1260,8 @@ describe("Plugins - DIF", () => {
         exp: expirationDate,
         sub: holderDID.toString(),
         vc: {
-          "@context": [W3CVerifiableCredentialContext.credential],
-          type: [W3CVerifiableCredentialType.credential],
+          "@context": ["https://www.w3.org/2018/credentials/v1"],
+          type: ["VerifiableCredential"],
           issuer: issuerDID.toString(),
           issuanceDate: new Date(issuanceDate).toISOString(),
           credentialSubject: {

--- a/tests/plugins/dif/PresentationVerify.test.ts
+++ b/tests/plugins/dif/PresentationVerify.test.ts
@@ -535,7 +535,7 @@ describe("Plugins - DIF", () => {
           descriptor_map: [
             {
               id: descriptor.id,
-              format: "sdjwt" as any,
+              format: "sd_jwt",
               path: "$.verifiablePresentation[0]",
             },
           ],

--- a/tests/plugins/dif/PresentationVerify.test.ts
+++ b/tests/plugins/dif/PresentationVerify.test.ts
@@ -245,7 +245,7 @@ describe("Plugins - DIF", () => {
         descriptor_map: [
           {
             id: "c3fd00a4-129d-49dc-a640-d84ad32826d9",
-            format: "sdjwt" as any,
+            format: "sd_jwt" as any,
             path: "$.verifiablePresentation[0]",
           },
         ],

--- a/tests/plugins/dif/PresentationVerify.test.ts
+++ b/tests/plugins/dif/PresentationVerify.test.ts
@@ -1,12 +1,23 @@
-import { vi, describe, expect, test, beforeEach } from 'vitest';
+import { describe, expect, test, beforeEach } from 'vitest';
+import type { DisclosureFrame, PresentationFrame, } from '@sd-jwt/types';
+
 import { DIF } from '../../../src/plugins/internal/dif/types';
 import { Task } from '../../../src/utils';
 import { Apollo, Castor } from '../../../src';
 import { JWT, SDJWT } from "../../../src/pollux/utils/jwt";
 import { PresentationVerify } from '../../../src/plugins/internal/dif/PresentationVerify';
+import { Curve, KeyTypes, W3CVerifiableCredentialContext, W3CVerifiableCredentialType } from '../../../src/domain';
+import { CreateSDJWT } from '../../../src/pollux/utils/jwt/CreateSDJWT';
+import { DIFModule } from '../../../src/plugins/internal/dif/module';
 
 describe("Plugins - DIF", () => {
-  let ctx: Task.Context;
+  let ctx: Task.Context<{
+    SDJWT: SDJWT,
+    JWT: JWT,
+    Apollo: Apollo,
+    Castor: Castor,
+    DIF: DIFModule
+  }>;
 
   beforeEach(() => {
     const apollo = new Apollo();
@@ -16,6 +27,7 @@ describe("Plugins - DIF", () => {
       Castor: castor,
       JWT: new JWT(),
       SDJWT: new SDJWT(),
+      DIF: new DIFModule(),
     });
   });
 
@@ -394,38 +406,152 @@ describe("Plugins - DIF", () => {
       await expect(result).rejects.toThrow('Verification failed for credential (eyJ0eXAiOi...): reason -> Invalid Claim: Expected the $.vc.credentialSubject.firstname field to be "not hola" but got "hola"');
     });
 
-    // for use with PresentationFrame feature [https://github.com/hyperledger-identus/sdk-ts/issues/362]
-    // test("Should Verify false when the verifier asks for a field that was not disclosed by the user", async () => {
-    /*
-      //At the presentation level the holder chooses which fields it wants to disclose to verifier
-      // presentationFrame: {
-      //   vc: {
-      //     credentialSubject: {
-      //       firstname: true,
-      //       email: false
-      //     }
-      //   }
-      // },
-      // const presentationSubmissionJSON = await pollux.createPresentationSubmission<CredentialType.SDJWT>(
-      //   presentationDefinition,
-      //   jwtCredential,
-      //   holderPrv,
-      //   { presentationFrame }
-      // );
-      //   jws = await this.SDJWT.createPresentationFor<any>({
-      //     jws: credential.id,
-      //     privateKey,
-      //     presentationFrame
-      //   });
+    test("Should Verify false when the verifier asks for a field that was not disclosed by the user", async () => {
+      const issuerSeed = ctx.Apollo.createRandomSeed().seed;
+      const holderSeed = ctx.Apollo.createRandomSeed().seed;
 
-      // requiredClaims: ['vc.credentialSubject.email']
-    //*/
-    //   const sut = ctx.run(new PresentationVerify({ presentation, presentationRequest }));
+      const issuerMasterSK = ctx.Apollo.createPrivateKey({
+        type: KeyTypes.EC,
+        curve: Curve.SECP256K1,
+        seed: Buffer.from(issuerSeed.value).toString("hex"),
+      });
+      const issuerAuthenticationSK = ctx.Apollo.createPrivateKey({
+        type: KeyTypes.EC,
+        curve: Curve.ED25519,
+        seed: Buffer.from(issuerSeed.value).toString("hex"),
+      });
 
-    //   // Fails despite the verifier asked for the email, the holder rejected disclosing it
-    //   expect(sut).to.eventually.be.rejectedWith(
-    //     "Invalid Claim: Expected one of the paths $.vc.credentialSubject.email, $.credentialSubject.email, $.email to exist."
-    //   );
-    // });
+      const holderMasterSK = ctx.Apollo.createPrivateKey({
+        type: KeyTypes.EC,
+        curve: Curve.SECP256K1,
+        seed: Buffer.from(issuerSeed.value).toString("hex"),
+      });
+      const holderAuthenticationSK = ctx.Apollo.createPrivateKey({
+        type: KeyTypes.EC,
+        curve: Curve.ED25519,
+        seed: Buffer.from(holderSeed.value).toString("hex"),
+      });
+
+      const issuerDID = await ctx.Castor.createPrismDID(
+        issuerMasterSK.publicKey(),
+        [],
+        [
+          issuerAuthenticationSK.publicKey()
+        ]
+      );
+
+      const holderDID = await ctx.Castor.createPrismDID(
+        holderMasterSK.publicKey(),
+        [],
+        [
+          holderAuthenticationSK.publicKey()
+        ]
+      );
+
+      const currentDate = new Date();
+      const nextMonthDate = new Date(currentDate);
+      nextMonthDate.setMonth(currentDate.getMonth() + 1);
+      const issuanceDate = currentDate.getTime();
+      const expirationDate = nextMonthDate.getTime();
+
+      const payload = {
+        iss: issuerDID.toString(),
+        nbf: issuanceDate,
+        exp: expirationDate,
+        sub: holderDID.toString(),
+        vc: {
+          "@context": [W3CVerifiableCredentialContext.credential],
+          type: [W3CVerifiableCredentialType.credential],
+          issuer: issuerDID.toString(),
+          issuanceDate: new Date(issuanceDate).toISOString(),
+          credentialSubject: {
+            firstname: "hola",
+            email: 'secret@email.com'
+          },
+        },
+        vct: issuerDID.toString()
+      };
+
+      const claims = {
+        firstname: {
+          type: 'string',
+          pattern: 'hola'
+        },
+        email: {
+          type: 'string',
+          pattern: '*'
+        }
+      }
+
+      const presentationFrame: PresentationFrame<typeof payload> = {
+        vc: {
+          credentialSubject: {
+            firstname: true,
+            email: false
+          }
+        }
+      }
+
+      const disclosureFrame: DisclosureFrame<typeof payload> = {
+        _sd: ["vc"],
+        vc: {
+          _sd: [
+            "@context",
+            "credentialSubject",
+            "issuanceDate",
+            "issuer",
+            "type"
+          ],
+          credentialSubject: {
+            _sd: ['email', 'firstname']
+          }
+        }
+      }
+
+      const createSDJWT = new CreateSDJWT<typeof payload>({
+        did: issuerDID,
+        payload,
+        privateKey: issuerAuthenticationSK,
+        disclosureFrame
+      });
+
+      const jwt = await ctx.run(createSDJWT);
+
+      const presentationDefinition = await ctx.DIF.createPresentationDefinition(claims, {
+        issuer: issuerDID.toString()
+      });
+
+      const presentationSubmissionJWS = await ctx.SDJWT.createPresentationFor<typeof payload>({
+        jws: jwt,
+        privateKey: issuerAuthenticationSK,
+        presentationFrame
+      });
+
+      const [descriptor] = presentationDefinition.presentation_definition.input_descriptors;
+      const presentation: DIF.EmbedTarget = {
+        presentation_submission: {
+          id: "f28b346e-c20e-4651-8c24-7f41a576cf26",
+          definition_id: "acd86273-5017-4980-a9be-dab6c725c811",
+          descriptor_map: [
+            {
+              id: descriptor.id,
+              format: "sdjwt" as any,
+              path: "$.verifiablePresentation[0]",
+            },
+          ],
+        },
+        verifiablePresentation: [
+          presentationSubmissionJWS
+        ],
+      };
+
+      const sut = ctx.run(new PresentationVerify({
+        presentation,
+        presentationRequest: presentationDefinition
+      }));
+
+      await expect(sut).rejects.toThrow('Verification failed for credential (eyJ0eXAiOi...): reason -> Invalid Claim: Expected one of the paths $.vc.credentialSubject.email, $.credentialSubject.email, $.email to exist.');
+
+    })
   });
 });


### PR DESCRIPTION
### Description: 
This PR ensures compliance with the  [DIF Presentation exchange protocol V2](https://identity.foundation/presentation-exchange/spec/v2.1.1)

Added fixes to properly validate submissions recursively using descriptor_item format and nested_paths.
Presentation Submission can now contain jwt_vc only, combination of jwt_vp + jwt_vc and sd_jwt submissions.
Added test coverage for edge cases, invalid or missing signatures and attributes

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
