### PR TITLE
feat(Pluto)!: updating Pluto to extend Startable

### DIFF
--- a/demos/node/src/sdkFns/didcommStart.ts
+++ b/demos/node/src/sdkFns/didcommStart.ts
@@ -34,7 +34,15 @@ export const DIDCommStart = new AsyncPrompt(
     // Agent orchestrates the SDK functionality
     const agent = SDK.Agent.initialize({ mediatorDID, pluto });
 
-    await agent.start();
+    try {
+      // ? should start be retry-able
+      await agent.start();
+    }
+    catch (err) {
+      // store is not controlled by the SDK
+      await store.clear();
+      throw err;
+    }
 
     agent.addListener(SDK.ListenerKey.CONNECTION, event => {
       state.notifications[SDK.ListenerKey.CONNECTION] = true;

--- a/src/domain/buildingBlocks/Pluto.ts
+++ b/src/domain/buildingBlocks/Pluto.ts
@@ -8,6 +8,7 @@ import { PeerDID } from "../../peer-did/PeerDID";
 import { uuid } from "@stablelib/uuid";
 import { Arrayable } from "../../utils";
 import * as Backup from "../backup";
+import { Startable } from "../protocols";
 
 export namespace Pluto {
   /**
@@ -32,15 +33,7 @@ export namespace Pluto {
  * which will be implemented using this SDK. Implement this interface using your
  * preferred underlying storage technology, most appropriate for your use case.
  */
-export interface Pluto {
-  // TODO apply breaking change below
-  // export interface Pluto extends Startable.IController {
-  /**
-   * Pluto initialise function
-   */
-  start(): Promise<void>;
-  stop?(): Promise<void>;
-
+export interface Pluto extends Startable.IController {
   /**
    * create a Backup object from the stored data
    */

--- a/src/pluto/Pluto.ts
+++ b/src/pluto/Pluto.ts
@@ -122,14 +122,6 @@ export class Pluto extends Startable.Controller implements Domain.Pluto {
     this.BackupMgr = new BackupManager(this, this.Repositories);
   }
 
-  // TODO breaking change workarounds
-  override async start(): Promise<any> {
-    return await super.start();
-  }
-  override async stop(): Promise<any> {
-    return await super.stop();
-  }
-
   protected async _start() {
     if (notNil(this.store.start)) {
       await this.store.start();

--- a/src/pluto/rxdb/Store.ts
+++ b/src/pluto/rxdb/Store.ts
@@ -1,4 +1,4 @@
-import { CollectionsOfDatabase, MangoQuery, RxDatabase, RxDatabaseCreator, RxDocument, addRxPlugin, createRxDatabase, removeRxDatabase } from 'rxdb';
+import { CollectionsOfDatabase, MangoQuery, RxDatabase, RxDatabaseCreator, RxDocument, addRxPlugin, createRxDatabase } from 'rxdb';
 import { RxDBJsonDumpPlugin } from 'rxdb/plugins/json-dump';
 import { RxDBQueryBuilderPlugin } from 'rxdb/plugins/query-builder';
 import { CollectionList, makeCollections } from "./collections";
@@ -115,6 +115,7 @@ export class RxdbStore implements Pluto.Store {
    */
   async clear() {
     await this.cleanup();
-    await removeRxDatabase(this.options.name, this.db.storage);
+    await this.db.remove();
+    delete this._db;
   }
 }


### PR DESCRIPTION
### Description: 
Updating Pluto to extend Startable, which was previously worked around to avoid a breaking change.
Also updated `Store.clear` function to fully remove persistent state and updated node demo accordingly.

BREAKING CHANGE:
Pluto.stop is now a required function 

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
