### PR TITLE
fix: add deprecation warning for rxdb

### DIFF
--- a/src/pluto/rxdb/Store.ts
+++ b/src/pluto/rxdb/Store.ts
@@ -15,6 +15,7 @@ export class RxdbStore implements Pluto.Store {
     private readonly options: RxDatabaseCreator,
     private readonly collections?: CollectionList
   ) {
+    console.warn("[DEPRECATION WARNING] RxdbStore is deprecated and future versions will no longer bundle it. Use @trust0/identus-store-rxdb in replacement for this class.");
     addRxPlugin(RxDBQueryBuilderPlugin);
     addRxPlugin(RxDBJsonDumpPlugin);
     addRxPlugin(RxDBEncryptedMigrationPlugin);


### PR DESCRIPTION
### Description: 
Simple PR tto add a deprecation warning, we are transitioning into not bundling  RXDB store wrapper for Pluto in our SDK, but replace this with good documentation on how to use the agent, etc.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
