### PR TITLE
fix: update signature encoding to follow JWS specification

### DIFF
--- a/src/pollux/utils/jwt/CreateJwt.ts
+++ b/src/pollux/utils/jwt/CreateJwt.ts
@@ -1,9 +1,11 @@
-import { ES256KSigner, EdDSASigner, Signer, createJWT } from "did-jwt";
+import { Signer, createJWT } from "did-jwt";
 import { base58btc } from "multiformats/bases/base58";
 import * as Domain from "../../../domain";
 import { asJsonObj, expect, notNil } from "../../../utils";
 import { Task } from "../../../utils/tasks";
 import { AgentContext } from "../../../edge-agent/didcomm/Context";
+import { base64url } from "multiformats/bases/base64";
+import { normaliseDER } from "./DER";
 
 /**
  * Asyncronously sign with a DID
@@ -31,15 +33,16 @@ export class CreateJWT extends Task<string, Args> {
     }
 
     const kid = await this.getSigningKid(ctx, this.args.did, privateKey);
+    const signer: Signer = async (data: any) => {
+      const rawSignature = privateKey.sign(Buffer.from(data));
+      //secp256k1 uses compact encoding while apollo returns der signatures so far
+      const signature = privateKey.curve === Domain.Curve.SECP256K1 ?
+        normaliseDER(rawSignature) :
+        rawSignature;
+      const encoded = base64url.baseEncode(signature);
+      return encoded;
+    };
 
-    let signer: Signer;
-    if (privateKey.curve === Domain.Curve.SECP256K1) {
-      signer = ES256KSigner(privateKey.raw);
-    } else if (privateKey.curve === Domain.Curve.ED25519) {
-      signer = EdDSASigner(privateKey.raw);
-    } else {
-      throw new Error("Unsupported curve");
-    }
     const jwt = await createJWT(
       this.args.payload,
       { issuer: this.args.did.toString(), signer },

--- a/src/pollux/utils/jwt/DER.ts
+++ b/src/pollux/utils/jwt/DER.ts
@@ -1,0 +1,69 @@
+/**
+ * Fix around normalising DER signatures into their raw representation
+ * @param derSignature Uint8Array
+ * @returns Uint8Array
+ */
+export function normaliseDER(derSignature: Uint8Array): Uint8Array {
+    // Ensure the DER signature starts with the correct sequence header
+    if (derSignature[0] !== 0x30) {
+        return derSignature;
+    }
+    // Get the length of the sequence
+    let seqLength = derSignature[1];
+    let offset = 2;
+    if (seqLength & 0x80) {
+        const lengthBytes = seqLength & 0x7f;
+        seqLength = 0;
+        for (let i = 0; i < lengthBytes; i++) {
+            seqLength = (seqLength << 8) | derSignature[offset++];
+        }
+    }
+
+    if (derSignature[offset++] !== 0x02) {
+        throw new Error('Invalid DER signature: expected integer for r');
+    }
+
+    const rLength = derSignature[offset++];
+    let r = Buffer.from(derSignature.slice(offset, offset + rLength));
+    offset += rLength;
+
+    // Extract s value
+    if (derSignature[offset++] !== 0x02) {
+        throw new Error('Invalid DER signature: expected integer for s');
+    }
+    const sLength = derSignature[offset++];
+    let s = Buffer.from(derSignature.slice(offset, offset + sLength));
+
+    // Normalize r and s to 32 bytes
+    if (r.length > 32) {
+        r = r.slice(-32); // truncate if r is longer than 32 bytes
+    } else if (r.length < 32) {
+        const paddedR = Uint8Array.from(Buffer.alloc(32));
+        r.copy(paddedR, 32 - r.length);
+        r = Buffer.from(paddedR); // left pad with zeros if r is shorter than 32 bytes
+    }
+
+    if (s.length > 32) {
+        s = s.slice(-32); // truncate if s is longer than 32 bytes
+    } else if (s.length < 32) {
+        const paddedS = Uint8Array.from(Buffer.alloc(32));
+        s.copy(paddedS, 32 - s.length);
+        s = Buffer.from(paddedS); // left pad with zeros if s is shorter than 32 bytes
+    }
+
+    // Concatenate r and s to form the raw signature
+    return Uint8Array.from([...r, ...s]);
+}
+/**
+ * Remove leading zeros from a buffer
+ * @param buffer Buffer
+ * @returns Buffer
+ */
+function removeLeadingZeros(buffer: Buffer): Buffer {
+    const arr = Array.from(buffer)
+    let i = 0;
+    while (i < arr.length - 1 && arr[i] === 0) {
+        i++;
+    }
+    return Buffer.from(arr.slice(i));
+}


### PR DESCRIPTION
### Description: 
The signed presentation for the credential request is DER-encoded, according to the JWS specification, the signature should not be DER-encoded. Instead, it should be a concatenation of R || S, Base64 URL-safe encoded (as per [RFC 7515, Section 8.1](https://datatracker.ietf.org/doc/html/rfc7515#page-45))

(https://github.com/hyperledger-identus/cloud-agent/issues/1541)

### Alternatives Considered (optional): 
Yes not follow the JWS and fix in cloud-agent to support both DER Encoded and JWS but will require handling both and wont benefit much, since it is JWT we should follow JWS spec

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
