### PR TITLE
docs: sdk/classes/Pollux is removed from the sidebars.js

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -63,7 +63,6 @@ const sidebars = {
         'sdk/classes/Agent',
         'pluto/README',
         'sdk/classes/Mercury',
-        'sdk/classes/Pollux',
         {
           type: 'category',
           label: 'Domain',


### PR DESCRIPTION
### Description: 
The hyperledger-identus/docs CI fails after updating submodules
It looks like after refactoring, the `sdk/classes/Pollux` was wiped or moved

[Link to the failed CI job](https://github.com/hyperledger-identus/docs/actions/runs/13922450601/job/38958667208#step:4:41)

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
