### PR TITLE
feat: export tasks

### DIFF
--- a/src/edge-agent/Agent.ts
+++ b/src/edge-agent/Agent.ts
@@ -105,7 +105,7 @@ export default class Agent extends Startable.Controller {
   }
 
   private runTask<T>(task: Task<T>) {
-    const ctx = Task.Context.make({
+    const ctx = new Task.Context({
       Api: this.api,
       Apollo: this.apollo,
       Castor: this.castor,

--- a/src/edge-agent/connections/Connection.ts
+++ b/src/edge-agent/connections/Connection.ts
@@ -1,5 +1,5 @@
 import * as Domain from "../../domain";
-import { DIDCommContext } from "../didcomm/Context";
+import { AgentContext } from "../didcomm/Context";
 
 /**
  * Define the structure of a Connection
@@ -17,11 +17,11 @@ export interface Connection {
   /**
    * handle delivering a Message to the connected entity
    */
-  send: (message: Domain.Message, ctx: DIDCommContext) => Promise<Domain.Message | undefined>;
+  send: (message: Domain.Message, ctx: AgentContext) => Promise<Domain.Message | undefined>;
   /**
    * called when a Message is received from this connection
    */
-  receive: (message: any, ctx: DIDCommContext) => Promise<void>;
+  receive: (message: any, ctx: AgentContext) => Promise<void>;
   /**
    * handle any desired teardown
    */

--- a/src/edge-agent/connections/didcomm/DIDCommConnection.ts
+++ b/src/edge-agent/connections/didcomm/DIDCommConnection.ts
@@ -1,5 +1,6 @@
 import * as Domain from "../../../domain";
 import { Ctor, Task, notNil } from "../../../utils";
+import { AgentContext } from "../../didcomm/Context";
 import { ProtocolType } from "../../protocols/ProtocolTypes";
 import { Connection } from "../Connection";
 import { MediateDeny } from "../didcomm/MediateDeny";
@@ -26,7 +27,7 @@ export class DIDCommConnection implements Connection {
       .set(ProtocolType.ProblemReporting, ProblemReport);
   }
 
-  async send(msg: Domain.Message, ctx: Task.Context) {
+  async send(msg: Domain.Message, ctx: AgentContext) {
     msg.direction = Domain.MessageDirection.SENT;
     // filter which messages we want stored
     const ignorePluto = [ProtocolType.PickupRequest, ProtocolType.DidcommMediationKeysUpdate];
@@ -42,7 +43,7 @@ export class DIDCommConnection implements Connection {
     return this.receive(response, ctx);
   }
 
-  async receive(msg: Domain.Message | undefined, ctx: Task.Context) {
+  async receive(msg: Domain.Message | undefined, ctx: AgentContext) {
     // find the relevant task - enable handling of unmatched
     const taskCtor = this.tasks.get(msg?.piuri ?? "unknown");
 

--- a/src/edge-agent/connections/didcomm/MediateDeny.ts
+++ b/src/edge-agent/connections/didcomm/MediateDeny.ts
@@ -1,6 +1,6 @@
 import * as Domain from "../../../domain";
 import { Task, expect } from "../../../utils";
-import { DIDCommContext } from "../../didcomm/Context";
+import { AgentContext } from "../../didcomm/Context";
 import { Connection } from "../Connection";
 
 /**
@@ -13,7 +13,7 @@ interface Args {
 }
 
 export class MediateDeny extends Task<void, Args> {
-  async run(ctx: DIDCommContext) {
+  async run(ctx: AgentContext) {
     ctx.logger.warn(`Mediation denied for: ${this.args.message.from?.toString()}`);
     ctx.logger.debug(`Mediate-Deny message:`, this.args.message);
 

--- a/src/edge-agent/connections/didcomm/MediateGrant.ts
+++ b/src/edge-agent/connections/didcomm/MediateGrant.ts
@@ -1,6 +1,6 @@
 import * as Domain from "../../../domain";
 import { Task, expect } from "../../../utils";
-import { DIDCommContext } from "../../didcomm/Context";
+import { AgentContext } from "../../didcomm/Context";
 import { Connection } from "../Connection";
 
 /**
@@ -17,7 +17,7 @@ interface Args {
 }
 
 export class MediateGrant extends Task<void, Args> {
-  async run(ctx: DIDCommContext) {
+  async run(ctx: AgentContext) {
     const uri = expect(this.args.message.from);
     const msgTo = expect(this.args.message.to);
     const routingDID = expect(this.args.message.body.routing_did, "routing_did not available on message body");

--- a/src/edge-agent/connections/didcomm/PickupDelivery.ts
+++ b/src/edge-agent/connections/didcomm/PickupDelivery.ts
@@ -6,7 +6,7 @@ import { RevocationNotification } from "../../protocols/revocation/RevocationNot
 import { ProtocolType } from "../../protocols/ProtocolTypes";
 import { IssueCredential } from "../../protocols/issueCredential/IssueCredential";
 import { HandleIssueCredential } from "../../didcomm/HandleIssueCredential";
-import { DIDCommContext } from "../../didcomm/Context";
+import { AgentContext } from "../../didcomm/Context";
 
 /**
  * Pickup Delivery
@@ -22,7 +22,7 @@ interface Args {
 }
 
 export class PickupDelivery extends Task<void, Args> {
-  async run(ctx: DIDCommContext) {
+  async run(ctx: AgentContext) {
     const msg = this.args.message;
     const connection = ctx.Connections.mediator;
     const mediator = expect(connection?.asMediator());

--- a/src/edge-agent/connections/didcomm/PickupStatus.ts
+++ b/src/edge-agent/connections/didcomm/PickupStatus.ts
@@ -1,6 +1,6 @@
 import * as Domain from "../../../domain";
 import { Task } from "../../../utils";
-import { DIDCommContext } from "../../didcomm/Context";
+import { AgentContext } from "../../didcomm/Context";
 
 /**
  * Pickup Status
@@ -13,7 +13,7 @@ interface Args {
 }
 
 export class PickupStatus extends Task<void, Args> {
-  async run(ctx: DIDCommContext) {
+  async run(ctx: AgentContext) {
     // do nothing
   }
 }

--- a/src/edge-agent/connections/didcomm/ProblemReport.ts
+++ b/src/edge-agent/connections/didcomm/ProblemReport.ts
@@ -1,7 +1,7 @@
 import * as Domain from "../../../domain";
 import { Task } from "../../../utils";
 import { ListenerKey } from "../../types";
-import { DIDCommContext } from "../../didcomm/Context";
+import { AgentContext } from "../../didcomm/Context";
 
 /**
  * Problem Report
@@ -12,7 +12,7 @@ interface Args {
 }
 
 export class ProblemReport extends Task<void, Args> {
-  async run(ctx: DIDCommContext) {
+  async run(ctx: AgentContext) {
     const msgs = [this.args.message];
     await ctx.Pluto.storeMessages(msgs);
     ctx.Events.emit(ListenerKey.MESSAGE, msgs);

--- a/src/edge-agent/didFunctions/CreatePrismDID.ts
+++ b/src/edge-agent/didFunctions/CreatePrismDID.ts
@@ -8,6 +8,7 @@ import {
   PrismDerivationPathSchema
 } from "../../domain/models/derivation/schemas/PrismDerivation";
 import { Task } from "../../utils/tasks";
+import { AgentContext } from "../didcomm/Context";
 import { PrismKeyPathIndexTask } from "./PrismKeyPathIndex";
 
 /**
@@ -25,7 +26,7 @@ interface Args {
 }
 
 export class CreatePrismDID extends Task<Domain.DID, Args> {
-  async run(ctx: Task.Context) {
+  async run(ctx: AgentContext) {
     const getIndexTask = new PrismKeyPathIndexTask({ index: this.args.keyPathIndex });
     const index = await ctx.run(getIndexTask);
 

--- a/src/edge-agent/didFunctions/PrismKeyPathIndex.ts
+++ b/src/edge-agent/didFunctions/PrismKeyPathIndex.ts
@@ -1,4 +1,5 @@
 import { Task } from "../../utils/tasks";
+import { AgentContext } from "../didcomm/Context";
 
 /**
  * Task to find the latest Prism DID KeyPathIndex
@@ -14,7 +15,7 @@ interface Args {
 }
 
 export class PrismKeyPathIndexTask extends Task<number, Args> {
-  async run(ctx: Task.Context) {
+  async run(ctx: AgentContext) {
     const { index } = this.args;
     const prismDIDs = await ctx.Pluto.getAllPrismDIDs();
 

--- a/src/edge-agent/didFunctions/Sign.ts
+++ b/src/edge-agent/didFunctions/Sign.ts
@@ -1,5 +1,6 @@
 import * as Domain from "../../domain";
 import { Task } from "../../utils/tasks";
+import { AgentContext } from "../didcomm/Context";
 
 /**
  * Asyncronously sign with a DID
@@ -16,7 +17,7 @@ interface Args {
 }
 
 export class SignWithDID extends Task<Domain.Signature, Args> {
-  async run(ctx: Task.Context) {
+  async run(ctx: AgentContext) {
     const privateKeys = await ctx.Pluto.getDIDPrivateKeysByDID(this.args.did);
 
     for (const privateKey of privateKeys) {

--- a/src/edge-agent/didcomm/Agent.ts
+++ b/src/edge-agent/didcomm/Agent.ts
@@ -44,6 +44,8 @@ import { Send } from "./Send";
 import { asJsonObj, isNil, notNil } from "../../utils";
 import { StartMediator } from "./StartMediator";
 import { StartFetchingMessages } from "./StartFetchingMessages";
+import { AgentContext } from "./Context";
+import { JWT, SDJWT } from "../../pollux/utils/jwt";
 
 /**
  * Edge agent implementation
@@ -195,8 +197,14 @@ export default class DIDCommAgent extends Startable.Controller {
       : undefined;
   }
 
-  private runTask<T>(task: Task<T>) {
-    const ctx = Task.Context.make({
+  /**
+   * run the given Task
+   * 
+   * @param task 
+   * @returns 
+   */
+  runTask<T>(task: Task<T>) {
+    const ctx = new AgentContext({
       Connections: this.connections,
       Plugins: this.plugins,
       Events: this.events,
@@ -207,6 +215,9 @@ export default class DIDCommAgent extends Startable.Controller {
       Castor: this.castor,
       Pluto: this.pluto,
       Seed: this.seed,
+
+      JWT: new JWT(),
+      SDJWT: new SDJWT(),
     });
 
     ctx.extend(this.plugins.getModules());

--- a/src/edge-agent/didcomm/Context.ts
+++ b/src/edge-agent/didcomm/Context.ts
@@ -1,12 +1,27 @@
+import type * as Domain from "../../domain";
 import { PluginManager } from "../../plugins";
+import { JWT, SDJWT } from "../../pollux/utils/jwt";
 import { Task } from "../../utils/tasks";
 import { EventsManager } from "../Agent.MessageEvents";
 import { ConnectionsManager } from "../connections/ConnectionsManager";
 import { JobManager } from "../connections/JobManager";
 
-export type DIDCommContext = Task.Context<{
+export class AgentContext extends Task.Context<{
+  // Agent modules
   Connections: ConnectionsManager;
   Plugins: PluginManager;
   Events: EventsManager;
   Jobs: JobManager;
-}>;
+
+  // Building Blocks
+  Api: Domain.Api;
+  Apollo: Domain.Apollo;
+  Castor: Domain.Castor;
+  Mercury: Domain.Mercury;
+  Pluto: Domain.Pluto;
+  Seed: Domain.Seed;
+
+  // internal modules
+  JWT: JWT;
+  SDJWT: SDJWT;
+}> {}

--- a/src/edge-agent/didcomm/CreatePeerDID.ts
+++ b/src/edge-agent/didcomm/CreatePeerDID.ts
@@ -1,7 +1,7 @@
 import * as Domain from "../../domain";
 import { Task } from "../../utils/tasks";
 import { MediationKeysUpdateList } from "../protocols/mediation/MediationKeysUpdateList";
-import { DIDCommContext } from "./Context";
+import { AgentContext } from "./Context";
 import { Send } from "./Send";
 
 /**
@@ -19,7 +19,7 @@ interface Args {
 }
 
 export class CreatePeerDID extends Task<Domain.DID, Args> {
-  async run(ctx: DIDCommContext): Promise<Domain.DID> {
+  async run(ctx: AgentContext): Promise<Domain.DID> {
     const services = this.args.services;
     const updateMediator = this.args.updateMediator ?? false;
     const publicKeys: Domain.PublicKey[] = [];
@@ -73,7 +73,7 @@ export class CreatePeerDID extends Task<Domain.DID, Args> {
    * @param {DID[]} did
    * @returns {Promise<void>}
    */
-  async updateKeyListWithDID(ctx: DIDCommContext, did: Domain.DID): Promise<void> {
+  async updateKeyListWithDID(ctx: AgentContext, did: Domain.DID): Promise<void> {
     const mediator = ctx.Connections.mediator?.asMediator();
 
     if (!mediator) {

--- a/src/edge-agent/didcomm/CreatePresentation.ts
+++ b/src/edge-agent/didcomm/CreatePresentation.ts
@@ -1,7 +1,7 @@
 import { uuid } from "@stablelib/uuid";
 import * as Domain from "../../domain";
 import { Presentation, RequestPresentation } from "../protocols/proofPresentation";
-import { DIDCommContext } from "./Context";
+import { AgentContext } from "./Context";
 import { Task } from "../../utils/tasks";
 import { expect, isString } from "../../utils";
 import { RunProtocol } from "../helpers/RunProtocol";
@@ -18,7 +18,7 @@ interface Args {
 }
 
 export class CreatePresentation extends Task<Presentation, Args> {
-  async run(ctx: DIDCommContext) {
+  async run(ctx: AgentContext) {
     const { credential, request } = this.args;
     const attachment = expect(request.attachments.at(0));
     const format = expect(attachment.format, "Invalid attachment format");

--- a/src/edge-agent/didcomm/CreatePresentationRequest.ts
+++ b/src/edge-agent/didcomm/CreatePresentationRequest.ts
@@ -3,12 +3,12 @@ import * as Domain from "../../domain";
 import { RequestPresentation } from "../protocols/proofPresentation";
 import { CreatePeerDID } from "./CreatePeerDID";
 import { Task } from "../../utils/tasks";
-import { DIDCommContext } from "./Context";
+import { AgentContext } from "./Context";
 import { Context as ACContext } from "../../plugins/internal/anoncreds";
 import { Context as DIFContext } from "../../plugins/internal/dif";
 
 // TODO tmp workaround using plugins in Agent task
-type TaskContext = DIDCommContext & ACContext & DIFContext;
+type TaskContext = AgentContext & ACContext & DIFContext;
 
 interface Args {
   type: Domain.CredentialType;

--- a/src/edge-agent/didcomm/HandleIssueCredential.ts
+++ b/src/edge-agent/didcomm/HandleIssueCredential.ts
@@ -3,7 +3,7 @@ import { expect } from "../../utils";
 import { Task } from "../../utils/tasks";
 import { RunProtocol } from "../helpers/RunProtocol";
 import { IssueCredential } from "../protocols/issueCredential/IssueCredential";
-import { DIDCommContext } from "./Context";
+import { AgentContext } from "./Context";
 
 /**
  * Extract the verifiableCredential object from the Issue credential message asyncronously
@@ -14,7 +14,7 @@ interface Args {
 }
 
 export class HandleIssueCredential extends Task<Domain.Credential, Args> {
-  async run(ctx: DIDCommContext) {
+  async run(ctx: AgentContext) {
     const { issueCredential } = this.args;
     const attachment = expect(issueCredential.attachments.at(0), "Invalid attachment");
     const format = expect(attachment.format, "Invalid attachment");

--- a/src/edge-agent/didcomm/HandleOOBInvitation.ts
+++ b/src/edge-agent/didcomm/HandleOOBInvitation.ts
@@ -2,7 +2,7 @@ import * as Domain from "../../domain";
 import { asArray, isNil, notNil } from "../../utils";
 import { Task } from "../../utils/tasks";
 import { OutOfBandInvitation } from "../protocols/invitation/v2/OutOfBandInvitation";
-import { DIDCommContext } from "./Context";
+import { AgentContext } from "./Context";
 import { CreatePeerDID } from "./CreatePeerDID";
 import { HandshakeRequest } from "../protocols/connection/HandshakeRequest";
 import { ListenerKey } from "../types";
@@ -20,7 +20,7 @@ interface Args {
 }
 
 export class HandleOOBInvitation extends Task<void, Args> {
-  async run(ctx: DIDCommContext) {
+  async run(ctx: AgentContext) {
     const attachment = asArray(this.args.invitation.attachments).at(0);
     // ?? make peerDID an arg - so we dont always create a new one
     const peerDID = await ctx.run(new CreatePeerDID({ services: [], updateMediator: true }));

--- a/src/edge-agent/didcomm/HandleOfferCredential.ts
+++ b/src/edge-agent/didcomm/HandleOfferCredential.ts
@@ -3,7 +3,7 @@ import * as Domain from "../../domain";
 import { OfferCredential } from "../protocols/issueCredential/OfferCredential";
 import { RequestCredential } from "../protocols/issueCredential/RequestCredential";
 import { Task } from "../../utils/tasks";
-import { DIDCommContext } from "./Context";
+import { AgentContext } from "./Context";
 import { expect, isString } from "../../utils";
 import { RunProtocol } from "../helpers/RunProtocol";
 
@@ -17,7 +17,7 @@ interface Args {
 }
 
 export class HandleOfferCredential extends Task<RequestCredential, Args> {
-  async run(ctx: DIDCommContext) {
+  async run(ctx: AgentContext) {
     const { offer } = this.args;
     const attachment = expect(offer.attachments.at(0), "Invalid attachment");
     const format = expect(attachment.format, "Invalid attachment format");

--- a/src/edge-agent/didcomm/HandlePresentation.ts
+++ b/src/edge-agent/didcomm/HandlePresentation.ts
@@ -4,14 +4,14 @@ import { Task } from "../../utils/tasks";
 import { RunProtocol } from "../helpers/RunProtocol";
 import { Presentation } from "../protocols/proofPresentation";
 import { ProtocolType } from "../protocols/ProtocolTypes";
-import { DIDCommContext } from "./Context";
+import { AgentContext } from "./Context";
 
 interface Args {
   presentation: Presentation;
 }
 
 export class HandlePresentation extends Task<boolean, Args> {
-  async run(ctx: DIDCommContext) {
+  async run(ctx: AgentContext) {
     const { presentation } = this.args;
 
     const attachment = expect(
@@ -39,7 +39,7 @@ export class HandlePresentation extends Task<boolean, Args> {
     return verified.data;
   }
 
-  private async getPresentationRequest(ctx: DIDCommContext, thid: string) {
+  private async getPresentationRequest(ctx: AgentContext, thid: string) {
     const allMessages = await ctx.Pluto.getAllMessages();
     const message = allMessages.find((message) => {
       return message.thid === thid && message.piuri === ProtocolType.DidcommRequestPresentation;

--- a/src/edge-agent/didcomm/ParseInvitation.ts
+++ b/src/edge-agent/didcomm/ParseInvitation.ts
@@ -7,6 +7,7 @@ import { ParsePrismInvitation } from "./ParsePrismInvitation";
 import { InvalidURLError, InvitationIsInvalidError } from "../../domain/models/errors/Agent";
 import { ParseOOBInvitation } from "./ParseOOBInvitation";
 import { InvitationType } from "../types";
+import { AgentContext } from "./Context";
 
 /**
  * Attempt to parse a given invitation based on its Type
@@ -18,7 +19,7 @@ interface Args {
 }
 
 export class ParseInvitation extends Task<InvitationType, Args> {
-  async run(ctx: Task.Context) {
+  async run(ctx: AgentContext) {
     const json = this.decode();
     const type = json.type ?? json.piuri;
 

--- a/src/edge-agent/didcomm/ParsePrismInvitation.ts
+++ b/src/edge-agent/didcomm/ParsePrismInvitation.ts
@@ -4,6 +4,7 @@ import { Task } from "../../utils/tasks";
 import { InvitationIsInvalidError } from "../../domain/models/errors/Agent";
 import { PrismOnboardingInvitation } from "../types";
 import { CreatePeerDID } from "./CreatePeerDID";
+import { AgentContext } from "./Context";
 
 /**
  * parse a prismOnboarding invitation
@@ -14,7 +15,7 @@ interface Args {
 }
 
 export class ParsePrismInvitation extends Task<PrismOnboardingInvitation, Args> {
-  async run(ctx: Task.Context) {
+  async run(ctx: AgentContext) {
     const json = asJsonObj(this.args.value);
     const endpoint = expect(json.onboardEndpoint, new InvitationIsInvalidError("Undefined PrismOnboardingInvitation onboardEndpoint"));
     const type = expect(json.type, new InvitationIsInvalidError("Undefined PrismOnboardingInvitation type"));

--- a/src/edge-agent/didcomm/Send.ts
+++ b/src/edge-agent/didcomm/Send.ts
@@ -3,7 +3,7 @@ import { expect, notNil } from "../../utils";
 import { Task } from "../../utils/tasks";
 import { Connection } from "../connections";
 import { DIDCommConnection } from "../connections/didcomm";
-import { DIDCommContext } from "./Context";
+import { AgentContext } from "./Context";
 
 /**
  * attempt to deliver a Message across a Connection
@@ -24,7 +24,7 @@ interface Args {
 }
 
 export class Send extends Task<Domain.Message | undefined, Args> {
-  async run(ctx: DIDCommContext) {
+  async run(ctx: AgentContext) {
     const uri = expect(this.args.message.to?.toString());
     const connection = this.args.connection ?? ctx.Connections.find(uri);
 

--- a/src/edge-agent/didcomm/StartFetchingMessages.ts
+++ b/src/edge-agent/didcomm/StartFetchingMessages.ts
@@ -3,7 +3,7 @@ import * as Domain from "../../domain";
 import { expect, isNil, notNil } from "../../utils";
 import { Task } from "../../utils/tasks";
 import { CancellableTask } from "../helpers/Task";
-import { DIDCommContext } from "./Context";
+import { AgentContext } from "./Context";
 import { ProtocolType } from "../protocols/ProtocolTypes";
 import { PickupRequest } from "../protocols/pickup/PickupRequest";
 
@@ -17,7 +17,7 @@ interface Args {
 }
 
 export class StartFetchingMessages extends Task<void, Args> {
-  async run(ctx: DIDCommContext) {
+  async run(ctx: AgentContext) {
     // check we're not already fetching messages
     if (notNil(ctx.Jobs.fetchMessages) || isNil(ctx.Connections.mediator)) {
       return;
@@ -69,7 +69,7 @@ export class StartFetchingMessages extends Task<void, Args> {
     }
   }
 
-  private async getSocketService(ctx: DIDCommContext) {
+  private async getSocketService(ctx: AgentContext) {
     const mediator = ctx.Connections.mediator;
 
     if (this.args.useSockets && mediator) {

--- a/src/edge-agent/didcomm/StartMediator.ts
+++ b/src/edge-agent/didcomm/StartMediator.ts
@@ -1,6 +1,6 @@
 import * as Domain from "../../domain";
 import { CreatePeerDID } from "./CreatePeerDID";
-import { DIDCommContext } from "./Context";
+import { AgentContext } from "./Context";
 import { Task } from "../../utils/tasks";
 import { expect } from "../../utils";
 import { MediationRequest } from "../protocols/mediation/MediationRequest";
@@ -20,7 +20,7 @@ interface Args {
 }
 
 export class StartMediator extends Task<void, Args> {
-  async run(ctx: DIDCommContext) {
+  async run(ctx: AgentContext) {
     try {
       // re-establish known connection
       const mediators = await ctx.Pluto.getAllMediators();
@@ -51,7 +51,7 @@ export class StartMediator extends Task<void, Args> {
    * @param {DID} host
    * @returns {Promise<Mediator>}
    */
-  private async achieveMediation(ctx: DIDCommContext) {
+  private async achieveMediation(ctx: AgentContext) {
     const host = await ctx.run(
       new CreatePeerDID({ services: [], updateMediator: false })
     );

--- a/src/edge-agent/helpers/RunProtocol.ts
+++ b/src/edge-agent/helpers/RunProtocol.ts
@@ -1,9 +1,7 @@
 import { Payload } from "../../domain/protocols/Payload";
 import { JsonObj, expect, isObject, notEmptyString, notNil } from "../../utils";
 import { Task } from "../../utils/tasks";
-import { DIDCommContext } from "../didcomm/Context";
-import { JWT, SDJWT } from "../../pollux/utils/jwt";
-import { Plugins } from "../../plugins";
+import { AgentContext } from "../didcomm/Context";
 import { Domain } from "../..";
 
 interface IArgs<T extends string, D extends JsonObj> {
@@ -42,18 +40,11 @@ type Args =
   | Args_RevocationCheck;
 
 export class RunProtocol extends Task<Payload, Args> {
-  async run(ctx: DIDCommContext) {
+  async run(ctx: AgentContext) {
     const taskCtor = expect(
       ctx.Plugins.findProtocol(this.args.type, this.args.pid),
       `Protocol handler not found for ${this.args.pid} (${this.args.type})`
     );
-
-    const internalModules: Plugins.InternalModules = {
-      JWT: new JWT(),
-      SDJWT: new SDJWT(),
-    };
-
-    ctx.extend(internalModules);
 
     const task = new taskCtor(this.args.data);
     const result = await ctx.run(task);

--- a/src/edge-agent/oidc/Agent.ts
+++ b/src/edge-agent/oidc/Agent.ts
@@ -91,7 +91,7 @@ export class OIDCAgent extends Startable.Controller {
   }
 
   private runTask<T>(task: Task<T>): Promise<T> {
-    const ctx = Task.Context.make({
+    const ctx = new Task.Context({
       Api: this.api,
       Apollo: this.apollo,
       Castor: this.castor,

--- a/src/edge-agent/oidc/tasks/CreateCredentialRequest.ts
+++ b/src/edge-agent/oidc/tasks/CreateCredentialRequest.ts
@@ -6,6 +6,7 @@ import { Task } from "../../../utils/tasks";
 import { CreatePrismDID } from "../../didFunctions/CreatePrismDID";
 import { CreateJWT } from "../../../pollux/utils/jwt/CreateJwt";
 import { InvalidCredentialConfigurationIds } from "../errors";
+import { AgentContext } from "../../didcomm/Context";
 
 interface Args {
   offer: OIDC.CredentialOffer;
@@ -15,7 +16,7 @@ interface Args {
 }
 
 export class CreateCredentialRequest extends Task<CredentialRequest, Args> {
-  async run(ctx: Task.Context) {
+  async run(ctx: AgentContext) {
     const credentialIssuer = this.args.offer.credential_issuer;
     const configId = expect(this.args.offer.credential_configuration_ids.at(0), InvalidCredentialConfigurationIds);
     const config = expect(this.args.issuerMeta.credential_configurations_supported[configId], InvalidCredentialConfigurationIds);

--- a/src/edge-agent/oidc/tasks/FetchAuthServerMeta.ts
+++ b/src/edge-agent/oidc/tasks/FetchAuthServerMeta.ts
@@ -1,6 +1,7 @@
 import * as Domain from "../../../domain";
 import { validate } from "../../../utils";
 import { Task } from "../../../utils/tasks";
+import { AgentContext } from "../../didcomm/Context";
 import { OIDC } from "../types";
 
 interface Args {
@@ -9,7 +10,7 @@ interface Args {
 }
 
 export class FetchAuthServerMeta extends Task<Domain.ApiResponse<OIDC.AuthServerMetadata>, Args> {
-  async run(ctx: Task.Context) {
+  async run(ctx: AgentContext) {
     const serverUrl = new URL(this.args.serverUri);
     const url = new URL(serverUrl);
 

--- a/src/edge-agent/oidc/tasks/FetchIssuerMetadata.ts
+++ b/src/edge-agent/oidc/tasks/FetchIssuerMetadata.ts
@@ -1,5 +1,6 @@
 import { validate } from "../../../utils";
 import { Task } from "../../../utils/tasks";
+import { AgentContext } from "../../didcomm/Context";
 import { OIDC } from "../types";
 
 interface Args {
@@ -7,7 +8,7 @@ interface Args {
 }
 
 export class FetchIssuerMetadata extends Task<OIDC.IssuerMetadata, Args> {
-  async run(ctx: Task.Context) {
+  async run(ctx: AgentContext) {
     const url = new URL(this.args.uri.toString());
     const agent_url = `${url}/.well-known/openid-credential-issuer`;
     const response = await ctx.Api.request("GET", agent_url);

--- a/src/edge-agent/oidc/tasks/HandleCredentialRequest.ts
+++ b/src/edge-agent/oidc/tasks/HandleCredentialRequest.ts
@@ -4,13 +4,14 @@ import { CredentialRequest } from "../protocols/CredentialRequest";
 import { Task } from "../../../utils/tasks";
 import { validate } from "../../../utils";
 import { JWTCredential } from "../../../pollux/models/JWTVerifiableCredential";
+import { AgentContext } from "../../didcomm/Context";
 
 interface Args {
   request: CredentialRequest;
 }
 
 export class HandleCredentialRequest extends Task<Domain.Credential, Args> {
-  async run(ctx: Task.Context) {
+  async run(ctx: AgentContext) {
     const response = await ctx.Api.request(
       this.args.request.method,
       this.args.request.url.href,

--- a/src/edge-agent/oidc/tasks/HandleTokenRequest.ts
+++ b/src/edge-agent/oidc/tasks/HandleTokenRequest.ts
@@ -4,13 +4,14 @@ import { Task } from "../../../utils/tasks";
 import { validate } from "../../../utils";
 import { OIDC } from "../types";
 import { InvalidTokenResponseStatus } from "../errors";
+import { AgentContext } from "../../didcomm/Context";
 
 interface Args {
   request: TokenRequest;
 }
 
 export class HandleTokenRequest extends Task<TokenResponse, Args> {
-  async run(ctx: Task.Context) {
+  async run(ctx: AgentContext) {
     const response = await ctx.Api.request(
       this.args.request.method,
       this.args.request.url.href,

--- a/src/edge-agent/oidc/tasks/ParseCredentialOffer.ts
+++ b/src/edge-agent/oidc/tasks/ParseCredentialOffer.ts
@@ -2,6 +2,7 @@ import { Task } from "../../../utils/tasks";
 import { asJsonObj, isObject, isString, notNil, validate } from "../../../utils";
 import { OIDC } from "../types";
 import { InvalidOffer } from "../errors";
+import { AgentContext } from "../../didcomm/Context";
 
 /**
  * attempt to extract a Credential Offer from the given value
@@ -14,7 +15,7 @@ interface Args {
 }
 
 export class ParseCredentialOffer extends Task<OIDC.CredentialOffer, Args> {
-  async run(ctx: Task.Context) {
+  async run(ctx: AgentContext) {
     try {
       const json = await this.extractJson(ctx);
       validate(json, OIDC.CredentialOffer);
@@ -27,7 +28,7 @@ export class ParseCredentialOffer extends Task<OIDC.CredentialOffer, Args> {
     }
   }
 
-  private async extractJson(ctx: Task.Context) {
+  private async extractJson(ctx: AgentContext) {
     if (isObject(this.args.value)) {
       return this.args.value;
     }

--- a/src/edge-agent/oidc/tasks/ResolveCredentialOffer.ts
+++ b/src/edge-agent/oidc/tasks/ResolveCredentialOffer.ts
@@ -7,6 +7,7 @@ import { InvalidCredentialConfigurationIds, MissingAuthorizationServerUri } from
 import { ProcessScopesAndConfigurationIds } from "./ProcessScopesAndConfigurationIds";
 import { FetchAuthServerMeta } from "./FetchAuthServerMeta";
 import { CreateAuthorizationRequest } from "./CreateAuthorizationRequest";
+import { AgentContext } from "../../didcomm/Context";
 
 /**
  * OIDC Authorization flow
@@ -21,7 +22,7 @@ interface Args {
 }
 
 export class ResolveCredentialOffer extends Task<AuthorizationRequest, Args> {
-  async run(ctx: Task.Context) {
+  async run(ctx: AgentContext) {
     const { offer, clientId, redirectUri } = this.args;
     const issuerMeta = await ctx.run(new FetchIssuerMetadata({ uri: offer.credential_issuer }));
     const supportedKeys = Object.keys(issuerMeta.credential_configurations_supported);

--- a/src/edge-agent/oidc/tasks/ResolveTokenRequest.ts
+++ b/src/edge-agent/oidc/tasks/ResolveTokenRequest.ts
@@ -6,6 +6,7 @@ import { TokenResponse } from "../protocols/TokenResponse";
 import { expect } from "../../../utils";
 import { Task } from "../../../utils/tasks";
 import { MissingClientId, MissingRedirectUri, RequiredCallbackUrl } from "../errors";
+import { AgentContext } from "../../didcomm/Context";
 
 interface Args {
   authorizationRequest: AuthorizationRequest;
@@ -13,7 +14,7 @@ interface Args {
 }
 
 export class ResolveTokenRequest extends Task<TokenResponse, Args> {
-  async run(ctx: Task.Context) {
+  async run(ctx: AgentContext) {
     // validateAuthResponse(this.authServerConfig!, { client_id: this.clientId }, new URL(window.location.href));
     const { authorizationRequest, callbackUrl } = this.args;
     const authMeta = authorizationRequest.authServerMeta;

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,3 +50,9 @@ import AnoncredsPlugin from "./plugins/internal/anoncreds";
 export const Plugins = {
   Anoncreds: AnoncredsPlugin
 };
+
+// Tasks
+import { CreatePrismDID } from "./edge-agent/didFunctions";
+export const Tasks = {
+  CreatePrismDID
+};

--- a/src/plugins/internal/anoncreds/FetchSchema.ts
+++ b/src/plugins/internal/anoncreds/FetchSchema.ts
@@ -1,3 +1,4 @@
+import { AgentContext } from "../../../edge-agent/didcomm/Context";
 import { Task } from "../../../utils";
 import * as Types from "./types";
 
@@ -6,7 +7,7 @@ interface Args {
 }
 
 export class fetchSchema extends Task<Types.Schema, Args> {
-  async run(ctx: Task.Context) {
+  async run(ctx: AgentContext) {
     const response = await ctx.Api.request("GET", this.args.uri);
     // [ ] validate <Anoncreds.CredentialSchemaType>
     return response.body as Types.Schema;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1,14 +1,9 @@
 import * as Utils from "../utils/tasks";
 import { Payload } from "../domain/protocols/Payload";
-import { JWT, SDJWT } from "../pollux/utils/jwt";
+import { AgentContext } from "../edge-agent/didcomm/Context";
 
 export namespace Plugins {
   export abstract class Task<T = unknown> extends Utils.Task<Payload, T> {}
 
-  export interface InternalModules {
-    JWT: JWT;
-    SDJWT: SDJWT;
-  }
-
-  export type Context<T = Record<string, never>> = Utils.Task.Context<T & InternalModules>;
+  export type Context<T = Record<string, never>> = Utils.Task.Context<T & AgentContext>;
 }

--- a/src/pollux/utils/jwt/CreateJwt.ts
+++ b/src/pollux/utils/jwt/CreateJwt.ts
@@ -4,6 +4,7 @@ import { base64url } from "multiformats/bases/base64";
 import * as Domain from "../../../domain";
 import { asJsonObj, expect, notNil } from "../../../utils";
 import { Task } from "../../../utils/tasks";
+import { AgentContext } from "../../../edge-agent/didcomm/Context";
 
 /**
  * Asyncronously sign with a DID
@@ -23,7 +24,7 @@ interface Args {
 }
 
 export class CreateJWT extends Task<string, Args> {
-  async run(ctx: Task.Context) {
+  async run(ctx: AgentContext) {
     const privateKey = await this.getPrivateKey(ctx);
 
     if (!privateKey.isSignable()) {
@@ -51,7 +52,7 @@ export class CreateJWT extends Task<string, Args> {
     return jwt;
   }
 
-  private async getPrivateKey(ctx: Task.Context) {
+  private async getPrivateKey(ctx: AgentContext) {
     if (notNil(this.args.privateKey)) {
       return this.args.privateKey;
     }
@@ -73,7 +74,7 @@ export class CreateJWT extends Task<string, Args> {
    * @param privateKey 
    * @returns {string} kid (key identifier)
    */
-  private async getSigningKid(ctx: Task.Context, did: Domain.DID, privateKey: Domain.PrivateKey) {
+  private async getSigningKid(ctx: AgentContext, did: Domain.DID, privateKey: Domain.PrivateKey) {
     const pubKey = privateKey.publicKey();
     const encoded = base58btc.encode(pubKey.to.Buffer());
     const document = await ctx.Castor.resolveDID(did.toString());

--- a/src/pollux/utils/jwt/FromJWK.ts
+++ b/src/pollux/utils/jwt/FromJWK.ts
@@ -3,143 +3,143 @@ import { expect, Task } from "../../../utils";
 
 import { base64url } from "multiformats/bases/base64";
 import { ApolloError, Curve, JWK, KeyPair, KeyProperties, PolluxError, PrivateKey, PublicKey } from "../../../domain";
+import { AgentContext } from "../../../edge-agent/didcomm/Context";
 
 export interface Args {
-    jwk: Domain.JWK;
+  jwk: Domain.JWK;
 }
 
 export class FromJWK extends Task<Domain.PublicKey | Domain.KeyPair, Args> {
 
-    private isECJWK(jwk: JWK): jwk is JWK.EC {
-        if (jwk.kty !== "EC") {
-            return false;
-        }
-        return true;
+  private isECJWK(jwk: JWK): jwk is JWK.EC {
+    if (jwk.kty !== "EC") {
+      return false;
     }
+    return true;
+  }
 
-    private isOKPJWK(jwk: JWK): jwk is JWK.OKP {
-        if (jwk.kty !== "OKP") {
-            return false;
-        }
-        return true;
+  private isOKPJWK(jwk: JWK): jwk is JWK.OKP {
+    if (jwk.kty !== "OKP") {
+      return false;
     }
+    return true;
+  }
 
 
-    private decodeJWKParameter(
-        coordinate: 'x' | 'y' | 'd',
-        jwk: JWK.EC | JWK.OKP
-    ): Uint8Array {
-        if (!jwk[coordinate]) {
-            throw new PolluxError.InvalidJWKParameters(coordinate, `Missing JWK Parameter`);
-        }
-        const coordinateValue = jwk[coordinate];
-        try {
-            if (typeof coordinateValue !== 'string') {
-                throw new PolluxError.InvalidJWKParameters(coordinate, `Invalid JWK Parameter, not string`);
-            }
-            const decoded = base64url.baseDecode(coordinateValue);
-            return new Uint8Array(decoded);
-        } catch (err) {
-            throw new PolluxError.InvalidJWKParameters(coordinate, `Invalid JWK Parameter, not base64url encoded`);
-        }
+  private decodeJWKParameter(
+    coordinate: 'x' | 'y' | 'd',
+    jwk: JWK.EC | JWK.OKP
+  ): Uint8Array {
+    if (!jwk[coordinate]) {
+      throw new PolluxError.InvalidJWKParameters(coordinate, `Missing JWK Parameter`);
     }
-
-
-    private isSupportedCurve(crv: string): asserts crv is Curve {
-        const keys = Object.values(Curve);
-        if (!keys.includes(crv as Curve)) {
-            throw new ApolloError.InvalidKeyCurve(crv);
-        }
+    const coordinateValue = jwk[coordinate];
+    try {
+      if (typeof coordinateValue !== 'string') {
+        throw new PolluxError.InvalidJWKParameters(coordinate, `Invalid JWK Parameter, not string`);
+      }
+      const decoded = base64url.baseDecode(coordinateValue);
+      return new Uint8Array(decoded);
+    } catch (err) {
+      throw new PolluxError.InvalidJWKParameters(coordinate, `Invalid JWK Parameter, not base64url encoded`);
     }
+  }
 
-    private fromJWKEC(apollo: Domain.Apollo, jwk: JWK.EC): KeyPair | PrivateKey | PublicKey {
-        const crv = expect(jwk.crv, new PolluxError.InvalidJWKParameters(['crv'], 'Missing JWK Parameter'));
-        this.isSupportedCurve(crv);
 
-        const withCoordinates =
-            jwk.x !== undefined ||
-            jwk.y !== undefined;
-
-        if (withCoordinates) {
-
-            const decodedX = this.decodeJWKParameter('x', jwk);
-            const decodedY = this.decodeJWKParameter('y', jwk);
-
-            let pk: PublicKey;
-            let sk: PrivateKey;
-
-            pk = apollo.createPublicKey({
-                [KeyProperties.curve]: crv,
-                [KeyProperties.curvePointX]: decodedX,
-                [KeyProperties.curvePointY]: decodedY
-            });
-
-            if (jwk.d !== undefined) {
-                const decodedD = this.decodeJWKParameter('d', jwk);
-                sk = apollo.createPrivateKey({
-                    [KeyProperties.curve]: crv,
-                    [KeyProperties.rawKey]: decodedD
-                });
-
-                const keypair: Domain.KeyPair = {
-                    privateKey: sk,
-                    publicKey: pk,
-                    curve: crv
-                }
-                return keypair;
-            }
-            return pk;
-        }
-
-        if (jwk.d !== undefined) {
-            const decodedD = this.decodeJWKParameter('d', jwk);
-            return apollo.createPrivateKey({
-                [KeyProperties.curve]: crv,
-                [KeyProperties.rawKey]: decodedD
-            })
-        }
-
-        throw new PolluxError.InvalidJWK('Required property x+y or d is missing in EC JWK');
+  private isSupportedCurve(crv: string): asserts crv is Curve {
+    const keys = Object.values(Curve);
+    if (!keys.includes(crv as Curve)) {
+      throw new ApolloError.InvalidKeyCurve(crv);
     }
+  }
 
-    private fromJWKOKP(apollo: Domain.Apollo, jwk: JWK.OKP): KeyPair | PublicKey {
-        const crv = expect(jwk.crv, new PolluxError.InvalidJWKParameters(['crv']));
-        this.isSupportedCurve(crv);
+  private fromJWKEC(apollo: Domain.Apollo, jwk: JWK.EC): KeyPair | PrivateKey | PublicKey {
+    const crv = expect(jwk.crv, new PolluxError.InvalidJWKParameters(['crv'], 'Missing JWK Parameter'));
+    this.isSupportedCurve(crv);
 
-        expect(jwk.x, new PolluxError.InvalidJWKParameters(['x'], 'Missing JWK Parameter x'));
+    const withCoordinates =
+      jwk.x !== undefined ||
+      jwk.y !== undefined;
 
-        const pk = apollo.createPublicKey({
-            [KeyProperties.curve]: crv,
-            [KeyProperties.rawKey]: this.decodeJWKParameter('x', jwk)
+    if (withCoordinates) {
+
+      const decodedX = this.decodeJWKParameter('x', jwk);
+      const decodedY = this.decodeJWKParameter('y', jwk);
+
+      let pk: PublicKey;
+      let sk: PrivateKey;
+
+      pk = apollo.createPublicKey({
+        [KeyProperties.curve]: crv,
+        [KeyProperties.curvePointX]: decodedX,
+        [KeyProperties.curvePointY]: decodedY
+      });
+
+      if (jwk.d !== undefined) {
+        const decodedD = this.decodeJWKParameter('d', jwk);
+        sk = apollo.createPrivateKey({
+          [KeyProperties.curve]: crv,
+          [KeyProperties.rawKey]: decodedD
         });
 
-        if (jwk.d !== undefined) {
-            const sk = apollo.createPrivateKey({
-                [KeyProperties.curve]: crv,
-                [KeyProperties.rawKey]: this.decodeJWKParameter('d', jwk)
-            });
-            const keypair: Domain.KeyPair = {
-                privateKey: sk,
-                publicKey: pk,
-                curve: crv
-            }
-            return keypair;
-        }
-
-        return pk;
+        const keypair: Domain.KeyPair = {
+          privateKey: sk,
+          publicKey: pk,
+          curve: crv
+        };
+        return keypair;
+      }
+      return pk;
     }
 
-    async run(ctx: Task.Context): Promise<Domain.PublicKey | Domain.KeyPair> {
-        const jwk = this.args.jwk;
-        const isEC = this.isECJWK(jwk);
-        const isOKP = this.isOKPJWK(jwk);
-        if (isEC) {
-            return this.fromJWKEC(ctx.Apollo, jwk);
-        }
-        if (isOKP) {
-            return this.fromJWKOKP(ctx.Apollo, jwk);
-        }
-        throw new PolluxError.InvalidJWKParameters(["kty"], "The kty field must be EC or OKP");
+    if (jwk.d !== undefined) {
+      const decodedD = this.decodeJWKParameter('d', jwk);
+      return apollo.createPrivateKey({
+        [KeyProperties.curve]: crv,
+        [KeyProperties.rawKey]: decodedD
+      });
     }
 
+    throw new PolluxError.InvalidJWK('Required property x+y or d is missing in EC JWK');
+  }
+
+  private fromJWKOKP(apollo: Domain.Apollo, jwk: JWK.OKP): KeyPair | PublicKey {
+    const crv = expect(jwk.crv, new PolluxError.InvalidJWKParameters(['crv']));
+    this.isSupportedCurve(crv);
+
+    expect(jwk.x, new PolluxError.InvalidJWKParameters(['x'], 'Missing JWK Parameter x'));
+
+    const pk = apollo.createPublicKey({
+      [KeyProperties.curve]: crv,
+      [KeyProperties.rawKey]: this.decodeJWKParameter('x', jwk)
+    });
+
+    if (jwk.d !== undefined) {
+      const sk = apollo.createPrivateKey({
+        [KeyProperties.curve]: crv,
+        [KeyProperties.rawKey]: this.decodeJWKParameter('d', jwk)
+      });
+      const keypair: Domain.KeyPair = {
+        privateKey: sk,
+        publicKey: pk,
+        curve: crv
+      };
+      return keypair;
+    }
+
+    return pk;
+  }
+
+  async run(ctx: AgentContext): Promise<Domain.PublicKey | Domain.KeyPair> {
+    const jwk = this.args.jwk;
+    const isEC = this.isECJWK(jwk);
+    const isOKP = this.isOKPJWK(jwk);
+    if (isEC) {
+      return this.fromJWKEC(ctx.Apollo, jwk);
+    }
+    if (isOKP) {
+      return this.fromJWKOKP(ctx.Apollo, jwk);
+    }
+    throw new PolluxError.InvalidJWKParameters(["kty"], "The kty field must be EC or OKP");
+  }
 }

--- a/src/pollux/utils/jwt/PKInstance.ts
+++ b/src/pollux/utils/jwt/PKInstance.ts
@@ -5,14 +5,14 @@ import { isObject, notEmptyString, Task } from "../../../utils";
 // TODO importing from Castor
 import { VerificationKeyType } from "../../../castor/types";
 import { FromJWK } from "./FromJWK";
+import { AgentContext } from "../../../edge-agent/didcomm/Context";
 export interface Args {
   verificationMethod: DIDResolver.VerificationMethod;
 }
 
 
 export class PKInstance extends Task<Domain.PublicKey | undefined, Args> {
-
-  async run(ctx: Task.Context) {
+  async run(ctx: AgentContext) {
     const verificationMethod = this.args.verificationMethod;
     let pk: Domain.PublicKey | undefined = undefined;
 

--- a/src/pollux/utils/jwt/ResolveDID.ts
+++ b/src/pollux/utils/jwt/ResolveDID.ts
@@ -1,13 +1,14 @@
 import type * as DIDResolver from "did-resolver";
 import * as Domain from "../../../domain";
 import { Task, asArray, isEmpty } from "../../../utils";
+import { AgentContext } from "../../../edge-agent/didcomm/Context";
 
 export interface Args {
   did: string;
 }
 
 export class ResolveDID extends Task<DIDResolver.DIDResolutionResult, Args> {
-  async run(ctx: Task.Context) {
+  async run(ctx: AgentContext) {
     const resolved = await ctx.Castor.resolveDID(this.args.did);
 
     const alsoKnownAs = resolved.coreProperties.find(

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,81 @@
+
+// ================================
+// === Logger ===
+// ================================
+
+export interface Logger {
+  /**
+   * very verbose information for debugging purposes
+   */
+  debug(message: string, ...params: any[]): void;
+  /**
+   * verbose information about normal operation
+   */
+  info(message: string, ...params: any[]): void;
+  /**
+   * expected information that might warrant require attention
+   */
+  warn(message: string, ...params: any[]): void;
+  /**
+   * unexpected or critical information
+   */
+  error(message: string, ...params: any[]): void;
+}
+
+export type LogLevel = "debug" | "info" | "warn" | "error" | "none";
+
+export class ConsoleLogger implements Logger {
+  private level: number;
+
+  constructor(logLevel?: LogLevel) {
+    this.level = this.getLogLevel(logLevel ?? "error");
+  }
+
+  getLogLevel(level: LogLevel): number {
+    switch (level) {
+      case "none": return 1;
+      case "debug": return 2;
+      case "info": return 3;
+      case "warn": return 4;
+      case "error": return 5;
+    }
+  }
+
+  debug(message: string, ...params: any[]) {
+    this.log("debug", message, ...params);
+  }
+
+  info(message: string, ...params: any[]) {
+    this.log("info", message, ...params);
+  }
+
+  warn(message: string, ...params: any[]) {
+    this.log("warn", message, ...params);
+  }
+
+  error(message: string, ...params: any[]) {
+    this.log("error", message, ...params);
+  }
+
+  private log(level: LogLevel, message: string, ...params: any[]) {
+    const logLevel = this.getLogLevel(level);
+
+    if (logLevel >= this.level) {
+      const item = {
+        level,
+        // identifier: this.identifier ?? "",
+        time: Date.now(),
+        message,
+        // params
+      };
+
+      if (params.length > 0) {
+        Object.assign(item, { params });
+      }
+
+      const output = JSON.stringify(item, null, 2);
+      // const output = JSON.stringify(item);
+      console.log(output);
+    }
+  }
+}

--- a/src/utils/tasks.ts
+++ b/src/utils/tasks.ts
@@ -1,8 +1,9 @@
-import * as Domain from "../domain";
+import { ConsoleLogger, Logger } from "./logger";
 import { expect } from "./guards";
 import { JsonObj } from "./types";
 
 /**
+ * A Task encapsulates a unit of work
  * 
  * args constructor parameter is mandatory if Args type given
  * args constructor parameter is optional if no Args type given
@@ -19,7 +20,7 @@ export abstract class Task<T, Args = unknown> {
     this.args = args ?? {} as Args;
   }
 
-  abstract run(ctx: Task.Context<any>): Promise<T>;
+  abstract run(ctx: Task.Context): Promise<T>;
 
   // return loggable information
   log(): unknown {
@@ -28,51 +29,16 @@ export abstract class Task<T, Args = unknown> {
 }
 
 export namespace Task {
-
-  // ================================
-  // === Context ===
-  // ================================
-
-  /**
-   * Context is provided to running tasks
-   * it optimistically provides access to Components
-   */
-  export type Context<T = JsonObj> = ContextProxy & Required<Context.Base> & T;
-
-  export namespace Context {
-    export type Options = Config & Base;
-
-    export interface Config {
-      logger?: ILogger;
-      logLevel?: LogLevel;
-    }
-
-    // base components
-    export interface Base {
-      Api?: Domain.Api;
-      Apollo?: Domain.Apollo;
-      Castor?: Domain.Castor;
-      Mercury?: Domain.Mercury;
-      Pluto?: Domain.Pluto;
-      Seed?: Domain.Seed;
-    }
-
-    export const make = <T extends Partial<Options>>(modules: T): Context<T> => {
-      const instance = new ContextProxy(modules);
-      return instance as Context<T>;
-    };
-  }
-
   /**
    * Context using proxy so we can extend arbitrarily
    */
   class ContextProxy {
-    public readonly logger: ILogger;
+    public readonly logger: Logger;
     private readonly modules: JsonObj = {};
     private readonly _proxy: any;
 
     constructor(private readonly opts: JsonObj) {
-      this.logger = opts.logger ?? new ConsoleLogger(opts.logLevel);
+      this.logger = opts.logger ?? new ConsoleLogger();
 
       const get = (target: any, prop: string) => {
         // return target.opts[prop] ?? target.modules[prop] ?? undefined;
@@ -110,6 +76,25 @@ export namespace Task {
     }
   }
 
+  /**
+   * used to mask the Proxy behaviour
+   * and enable Typescript to know what Modules should be accessible
+   */
+  interface ContextCtor {
+    new <T extends object>(modules: T): Context<T>;
+  }
+
+  /**
+   * Context is provided to running tasks
+   * it optimistically provides access to Modules
+   */
+  export type Context<T = JsonObj> = T & ContextProxy;
+  export const Context = ContextProxy as ContextCtor;
+
+  /**
+   * used to enable Modules to propagate the Context
+   * and have access to runTask
+   */
   export abstract class Runner {
     private context?: Context;
 
@@ -125,88 +110,6 @@ export namespace Task {
     protected runTask<T>(task: Task<T>): Promise<T> {
       const ctx = expect(this.context, `${this.constructor.name}: no Context available`);
       return ctx.run(task);
-    }
-  }
-
-
-  // ================================
-  // === Logger ===
-  // ================================
-
-  interface ILogger {
-    /**
-     * very verbose information for debugging purposes
-     */
-    debug(message: string, ...params: any[]): void;
-    /**
-     * verbose information about normal operation
-     */
-    info(message: string, ...params: any[]): void;
-    /**
-     * expected information that might warrant require attention
-     */
-    warn(message: string, ...params: any[]): void;
-    /**
-     * unexpected or critical information
-     */
-    error(message: string, ...params: any[]): void;
-  }
-
-  type LogLevel = "debug" | "info" | "warn" | "error" | "none";
-
-  class ConsoleLogger implements ILogger {
-    private level: number;
-
-    constructor(logLevel?: LogLevel) {
-      this.level = this.getLogLevel(logLevel ?? "error");
-    }
-
-    getLogLevel(level: LogLevel): number {
-      switch (level) {
-        case "none": return 1;
-        case "debug": return 2;
-        case "info": return 3;
-        case "warn": return 4;
-        case "error": return 5;
-      }
-    }
-
-    debug(message: string, ...params: any[]) {
-      this.log("debug", message, ...params);
-    }
-
-    info(message: string, ...params: any[]) {
-      this.log("info", message, ...params);
-    }
-
-    warn(message: string, ...params: any[]) {
-      this.log("warn", message, ...params);
-    }
-
-    error(message: string, ...params: any[]) {
-      this.log("error", message, ...params);
-    }
-
-    private log(level: LogLevel, message: string, ...params: any[]) {
-      const logLevel = this.getLogLevel(level);
-
-      if (logLevel >= this.level) {
-        const item = {
-          level,
-          // identifier: this.identifier ?? "",
-          time: Date.now(),
-          message,
-          // params
-        };
-
-        if (params.length > 0) {
-          Object.assign(item, { params });
-        }
-
-        const output = JSON.stringify(item, null, 2);
-        // const output = JSON.stringify(item);
-        console.log(output);
-      }
     }
   }
 }

--- a/tests/agent/StartFetchingMessages.test.ts
+++ b/tests/agent/StartFetchingMessages.test.ts
@@ -23,7 +23,7 @@ describe("StartFetchingMessages", () => {
     connections = { get mediator() { return mockMediator(); } } as any;
     mercury = { sendMessageParseMessage: vi.fn() } as any;
     pluto = mockPluto();
-    ctx = Task.Context.make({
+    ctx = new Task.Context({
       Connections: connections,
       Castor: { resolveDID: vi.fn() } as any,
       Jobs: new JobManager(),

--- a/tests/agent/StartMediator.test.ts
+++ b/tests/agent/StartMediator.test.ts
@@ -21,7 +21,7 @@ describe("StartMediator", () => {
       sendMessageParseMessage: vi.fn()
     } as any;
     pluto = mockPluto();
-    ctx = Task.Context.make({
+    ctx = new Task.Context({
       Connections: connections,
       Mercury: mercury,
       Pluto: pluto,

--- a/tests/agent/didcomm/HandleIssueCredential.test.ts
+++ b/tests/agent/didcomm/HandleIssueCredential.test.ts
@@ -11,7 +11,7 @@ describe("Agent", () => {
   let ctx: Task.Context;
 
   beforeEach(() => {
-    ctx = Task.Context.make({});
+    ctx = new Task.Context({});
   });
 
 

--- a/tests/agent/oidc/task.FetchIssuerMetadata.test.ts
+++ b/tests/agent/oidc/task.FetchIssuerMetadata.test.ts
@@ -20,7 +20,7 @@ describe("OIDC Tasks", () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    ctx = Task.Context.make({
+    ctx = new Task.Context({
       Api: { request: vi.fn() }
     });
   });

--- a/tests/agent/oidc/task.ParseCredentialOffer.test.ts
+++ b/tests/agent/oidc/task.ParseCredentialOffer.test.ts
@@ -18,7 +18,7 @@ describe("OIDC Tasks", () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    ctx = Task.Context.make<any>({
+    ctx = new Task.Context<any>({
       Api: { request: vi.fn() }
     });
   });

--- a/tests/plugins/anoncreds/PresentationRequest.test.ts
+++ b/tests/plugins/anoncreds/PresentationRequest.test.ts
@@ -15,7 +15,7 @@ describe("Plugins - Anoncreds", () => {
 
   beforeEach(() => {
     pluto = mockPluto();
-    ctx = Task.Context.make({
+    ctx = new Task.Context({
       Pluto: pluto,
       Anoncreds: new AnoncredsLoader(),
     });

--- a/tests/plugins/anoncreds/PresentationVerify.test.ts
+++ b/tests/plugins/anoncreds/PresentationVerify.test.ts
@@ -15,7 +15,7 @@ describe("Plugins - Anoncreds", () => {
 
   beforeEach(() => {
     pluto = mockPluto();
-    ctx = Task.Context.make({
+    ctx = new Task.Context({
       Pluto: pluto,
       Anoncreds: new AnoncredsLoader(),
     });

--- a/tests/plugins/dif/CreatePresentationDefinition.test.ts
+++ b/tests/plugins/dif/CreatePresentationDefinition.test.ts
@@ -10,7 +10,7 @@ describe("Plugins - DIF", () => {
   beforeEach(() => {
     const apollo = new Apollo();
     const castor = new Castor(apollo);
-    ctx = Task.Context.make<any>({
+    ctx = new Task.Context<any>({
       Apollo: apollo,
       Castor: castor,
       JWT: new JWT(),

--- a/tests/plugins/dif/IsCredentialRevoked.test.ts
+++ b/tests/plugins/dif/IsCredentialRevoked.test.ts
@@ -21,7 +21,7 @@ describe("Plugins - DIF", () => {
         request: async () => new ApiResponse<any>(new Uint8Array(), 200),
       };
       apollo = new Apollo();
-      ctx = Task.Context.make({
+      ctx = new Task.Context({
         Api: api,
         Apollo: apollo,
       });

--- a/tests/plugins/dif/PresentationRequest.test.ts
+++ b/tests/plugins/dif/PresentationRequest.test.ts
@@ -14,7 +14,7 @@ describe("Plugins - DIF", () => {
     const apollo = new Apollo();
     const castor = new Castor(apollo);
     const pluto = mockPluto();
-    ctx = Task.Context.make<any>({
+    ctx = new Task.Context<any>({
       Apollo: apollo,
       Castor: castor,
       Pluto: pluto,

--- a/tests/plugins/dif/PresentationVerify.test.ts
+++ b/tests/plugins/dif/PresentationVerify.test.ts
@@ -17,13 +17,13 @@ describe("Plugins - DIF", () => {
     JWT: JWT,
     Apollo: Apollo,
     Castor: Castor,
-    DIF: DIFModule
+    DIF: DIFModule;
   }>;
 
   beforeEach(() => {
     const apollo = new Apollo();
     const castor = new Castor(apollo);
-    ctx = Task.Context.make<any>({
+    ctx = new Task.Context<any>({
       Apollo: apollo,
       Castor: castor,
       JWT: new JWT(),
@@ -300,7 +300,7 @@ describe("Plugins - DIF", () => {
               ]
             }
           };
-          const presentationJWT = await ctx.JWT.signWithDID(holderDID, vpPayload, undefined, issuerAuthenticationSK)
+          const presentationJWT = await ctx.JWT.signWithDID(holderDID, vpPayload, undefined, issuerAuthenticationSK);
 
 
           const presentation: DIF.EmbedTarget = {
@@ -399,7 +399,7 @@ describe("Plugins - DIF", () => {
           await expect(result).rejects.toThrow(
             `Verification failed for credential (eyJhbGciOi...): reason -> Invalid Verifiable Presentation JWS Signature`
           );
-        })
+        });
 
 
 
@@ -483,7 +483,7 @@ describe("Plugins - DIF", () => {
               ]
             }
           };
-          const presentationJWT = await ctx.JWT.signWithDID(holderDID, vpPayload, undefined, holderMasterSK)
+          const presentationJWT = await ctx.JWT.signWithDID(holderDID, vpPayload, undefined, holderMasterSK);
 
 
           const presentation: DIF.EmbedTarget = {
@@ -578,14 +578,14 @@ describe("Plugins - DIF", () => {
           await expect(result).rejects.toThrow(
             `Verification failed for credential (eyJhbGciOi...): reason -> Invalid Verifiable Credential JWS Signature`
           );
-        })
+        });
 
         test("Should verify true when presentation is valid using jwt_vc and jwt_vp with nested paths", async () => {
           const sut = new PresentationVerify({ presentation, presentationRequest, });
           const result = await ctx.run(sut);
 
           expect(result.data).toBe(true);
-        })
+        });
 
         test("Should verify true when the presentation is valid,using jwt_vc only", async () => {
 
@@ -1281,7 +1281,7 @@ describe("Plugins - DIF", () => {
           type: 'string',
           pattern: '*'
         }
-      }
+      };
 
       const presentationFrame: PresentationFrame<typeof payload> = {
         vc: {
@@ -1290,7 +1290,7 @@ describe("Plugins - DIF", () => {
             email: false
           }
         }
-      }
+      };
 
       const disclosureFrame: DisclosureFrame<typeof payload> = {
         _sd: ["vc"],
@@ -1306,7 +1306,7 @@ describe("Plugins - DIF", () => {
             _sd: ['email', 'firstname']
           }
         }
-      }
+      };
 
       const createSDJWT = new CreateSDJWT<typeof payload>({
         did: issuerDID,
@@ -1352,6 +1352,6 @@ describe("Plugins - DIF", () => {
 
       await expect(sut).rejects.toThrow('Verification failed for credential (eyJ0eXAiOi...): reason -> Invalid Claim: Expected one of the paths $.vc.credentialSubject.email, $.credentialSubject.email, $.email to exist.');
 
-    })
+    });
   });
 });

--- a/tests/plugins/oea/jwt/CredentialIssue.test.ts
+++ b/tests/plugins/oea/jwt/CredentialIssue.test.ts
@@ -12,7 +12,7 @@ describe("Plugins - OEA", () => {
   beforeEach(() => {
     const apollo = new Apollo();
     const castor = new Castor(apollo);
-    ctx = Task.Context.make<any>({
+    ctx = new Task.Context<any>({
       Apollo: apollo,
       Castor: castor,
       JWT: new JWT(),

--- a/tests/plugins/oea/sdjwt/CredentialIssue.test.ts
+++ b/tests/plugins/oea/sdjwt/CredentialIssue.test.ts
@@ -11,7 +11,7 @@ describe("Plugins - OEA", () => {
   beforeEach(() => {
     const apollo = new Apollo();
     const castor = new Castor(apollo);
-    ctx = Task.Context.make<any>({
+    ctx = new Task.Context<any>({
       Apollo: apollo,
       Castor: castor,
       JWT: new JWT(),

--- a/tests/plugins/oea/sdjwt/PresentationRequest.test.ts
+++ b/tests/plugins/oea/sdjwt/PresentationRequest.test.ts
@@ -17,7 +17,7 @@ describe("Plugins - OEA", () => {
   beforeEach(() => {
     pluto = mockPluto();
 
-    ctx = Task.Context.make<any>({
+    ctx = new Task.Context<any>({
       Pluto: pluto,
       JWT: new JWT(),
       SDJWT: new SDJWT(),

--- a/tests/pollux/FromJWK.test.ts
+++ b/tests/pollux/FromJWK.test.ts
@@ -5,249 +5,249 @@ import { FromJWK } from '../../src/pollux/utils/jwt/FromJWK';
 import { ApolloError, Curve, JWK, PolluxError, PrivateKey, PublicKey } from '../../src/domain';
 
 describe("Pollux - JWT FromJWK", async () => {
-    let ctx: Task.Context<{
-        Apollo: Domain.Apollo;
-    }>;
-    let apollo: Domain.Apollo;
-    let castor: Domain.Castor;
+  let ctx: Task.Context<{
+    Apollo: Domain.Apollo;
+  }>;
+  let apollo: Domain.Apollo;
+  let castor: Domain.Castor;
 
-    beforeEach(() => {
-        apollo = new Apollo();
-        castor = new Castor(apollo);
-        ctx = Task.Context.make({
-            Apollo: apollo,
-        });
+  beforeEach(() => {
+    apollo = new Apollo();
+    castor = new Castor(apollo);
+    ctx = new Task.Context({
+      Apollo: apollo,
+    });
+  });
+
+
+  describe("fromJWK", () => {
+
+    it("Should throw an error if the key type is not EC or OKP", async () => {
+      const sut = new FromJWK({
+        jwk: {
+          kty: "oct",
+          k: "1234567890"
+        }
+      }).run(ctx);
+      await expect(sut).rejects.toThrow("19: The kty field must be EC or OKP");
+    });
+
+    describe("EC Key type with secp256k1 curve", async () => {
+
+      it("Should throw an error if both coordinates and d are missing", async () => {
+        const sut = new FromJWK({
+          jwk: {
+            kty: "EC",
+            crv: Curve.SECP256K1,
+          }
+        }).run(ctx);
+        await expect(sut).rejects.toThrow("20: Required property x+y or d is missing in EC JWK");
+      });
+
+      it("Should throw an error if only one coordinate coordinate is present", async () => {
+        const sut = new FromJWK({
+          jwk: {
+            kty: "EC",
+            crv: Curve.SECP256K1,
+            x: "poDxfZtoOpBDtFqJmJ03_tei3ooCXrGXkJM_WUErZPM",
+          }
+        }).run(ctx);
+        await expect(sut).rejects.toThrow("19: Missing JWK Parameter: y");
+
+        const sut2 = new FromJWK({
+          jwk: {
+            kty: "EC",
+            crv: Curve.SECP256K1,
+            y: "M6WTO1raVf2TNHO7t0IpiurajRo6k12HbJvNa2L-8sA",
+          }
+        }).run(ctx);
+        await expect(sut2).rejects.toThrow("19: Missing JWK Parameter: x");
+      });
+
+      it("Should throw an error if d is present but invalid", async () => {
+        const sut = new FromJWK({
+          jwk: {
+            kty: "EC",
+            crv: Curve.SECP256K1,
+            d: "adsasdasdadsadsasd",
+          }
+        }).run(ctx);
+        await expect(sut).rejects.toThrow("19: Invalid JWK Parameter, not base64url encoded: d");
+      });
+
+      it("Should throw an error if d is present but curve is unsupported", async () => {
+        const sut = new FromJWK({
+          jwk: {
+            kty: "EC",
+            crv: "wrong curve",
+            d: "adsasdasdadsadsasd",
+          }
+        }).run(ctx);
+        await expect(sut).rejects.toThrow(ApolloError.InvalidKeyCurve);
+      });
+
+      it("Should throw an error if coordinate encoding is not valid", async () => {
+        const sut = new FromJWK({
+          jwk: {
+            kty: "EC",
+            crv: Curve.SECP256K1,
+            //Should be base64url encoded
+            x: "1234567890",
+            y: "1234567890"
+          }
+        }).run(ctx);
+        await expect(sut).rejects.toThrow(PolluxError.InvalidJWKParameters);
+      });
+
+      it("Should not allow restoring from coordinates for non secp256k1 curves", async () => {
+        const sut = new FromJWK({
+          jwk: {
+            kty: "EC",
+            crv: Curve.ED25519,
+            x: "poDxfZtoOpBDtFqJmJ03_tei3ooCXrGXkJM_WUErZPM",
+            y: "M6WTO1raVf2TNHO7t0IpiurajRo6k12HbJvNa2L-8sA",
+          }
+        }).run(ctx);
+        await expect(sut).rejects.toThrow("16: Invalid key curve: Ed25519. Valid options are: secp256k1");
+      });
+
+      it("Should allow to recover a public key from x and y coordinates", async () => {
+        const sut = await new FromJWK({
+          jwk: {
+            kty: "EC",
+            crv: Curve.SECP256K1,
+            x: "poDxfZtoOpBDtFqJmJ03_tei3ooCXrGXkJM_WUErZPM",
+            y: "M6WTO1raVf2TNHO7t0IpiurajRo6k12HbJvNa2L-8sA",
+          }
+        }).run(ctx);
+        expect(sut).to.be.an.instanceOf(Secp256k1PublicKey);
+      });
+
+      it("Should allow to recover a keyPair key from x and y coordinates and d private key", async () => {
+        const sut = await new FromJWK({
+          jwk: {
+            kty: "EC",
+            crv: Curve.SECP256K1,
+            d: "ZLc6z-hpXb7RjPEve9rf-v44ElZJ-NQ5r0lqY-NpCuA",
+            x: "wYMtiI5wJqztx6ywMtm9ns8Pnlsq7_ZMj_gJh9DXiL0",
+            y: "g2p7eYiPxPMlZHQE95uV91gnwCMnOozpctwOPWzTCsM",
+          }
+        }).run(ctx);
+
+        expect(sut).toHaveProperty("privateKey");
+        expect(sut).toHaveProperty("publicKey");
+
+        expect((sut as Domain.KeyPair).privateKey).to.be.an.instanceOf(Secp256k1PrivateKey);
+        expect((sut as Domain.KeyPair).publicKey).to.be.an.instanceOf(Secp256k1PublicKey);
+      });
+
     });
 
 
-    describe("fromJWK", () => {
 
-        it("Should throw an error if the key type is not EC or OKP", async () => {
+
+    describe("OKP Key type", async () => {
+
+      const supportedCurves = [Curve.ED25519, Curve.X25519];
+      const fixTures: Record<string, { private: JWK.OKP, public: JWK.OKP; }> = {
+        [Curve.ED25519]: {
+          private: {
+            "kty": "OKP",
+            "d": "c3sPtGX-Jy4Ayi1RUz27UIS4ztWSEfJdQ3etgsjBl5M",
+            "crv": "Ed25519",
+            "x": "j7J_Y6I6Qg0RRFmBw5kJhxj9IsYrLw57c0NTeh5WNiI",
+            "alg": "EdDSA"
+          },
+          public: {
+            "kty": "OKP",
+            "crv": "Ed25519",
+            "x": "j7J_Y6I6Qg0RRFmBw5kJhxj9IsYrLw57c0NTeh5WNiI",
+            "alg": "EdDSA"
+          }
+        },
+        [Curve.X25519]: {
+          private: {
+            "kty": "OKP",
+            "d": "jZ52YidJvBz6GUroCIvasKSIAUrfp5Nk59zaM8biVIw",
+            "crv": "X25519",
+            "x": "eKj9zIA32kZc9jwSGnix2i8aiJo-ovrB8FeJkFwpMBE",
+            "alg": "EdDSA"
+          },
+          public: {
+            "kty": "OKP",
+            "crv": "X25519",
+            "x": "eKj9zIA32kZc9jwSGnix2i8aiJo-ovrB8FeJkFwpMBE",
+            "alg": "EdDSA"
+          }
+        }
+      };
+
+      it("Should throw an error if the curve is not supported", async () => {
+        const sut = new FromJWK({
+          jwk: {
+            ...fixTures[Curve.ED25519].public,
+            crv: "wrong curve",
+            x: undefined
+          } as any
+        }).run(ctx);
+        await expect(sut).rejects.toThrow("16: Invalid key curve: wrong curve. Valid options are: X25519, Ed25519, secp256k1");
+      });
+
+
+      supportedCurves.forEach(curve => {
+        describe(`${curve} curve`, () => {
+          it(`${curve} Should throw an error if x is missing`, async () => {
             const sut = new FromJWK({
-                jwk: {
-                    kty: "oct",
-                    k: "1234567890"
-                }
+              jwk: {
+                ...fixTures[curve].public,
+                x: undefined
+              } as any
             }).run(ctx);
-            await expect(sut).rejects.toThrow("19: The kty field must be EC or OKP");
+            await expect(sut).rejects.toThrow("19: Missing JWK Parameter x");
+          });
+
+          it(`${curve} Should throw an error if x is not encoded with base64url`, async () => {
+            const sut = new FromJWK({
+              jwk: {
+                ...fixTures[curve].public,
+                x: 'no'
+              } as any
+            }).run(ctx);
+            await expect(sut).rejects.toThrow("19: Invalid JWK Parameter, not base64url encoded: x");
+          });
+          it(`${curve} Should throw an error if d property is not encoded with base64url`, async () => {
+            const sut = new FromJWK({
+              jwk: {
+                ...fixTures[curve].private,
+                d: 'no'
+              } as any
+            }).run(ctx);
+            await expect(sut).rejects.toThrow("19: Invalid JWK Parameter, not base64url encoded: d");
+          });
+          it(`${curve} Should return a keyPair if x and d are present`, async () => {
+            const sut = await new FromJWK({
+              jwk: fixTures[curve].private
+            }).run(ctx);
+
+            expect(sut).toHaveProperty("privateKey");
+            expect(sut).toHaveProperty("publicKey");
+            expect(sut).toHaveProperty("curve");
+            expect((sut as Domain.KeyPair).privateKey).to.be.an.instanceOf(PrivateKey);
+            expect((sut as Domain.KeyPair).publicKey).to.be.an.instanceOf(PublicKey);
+            expect(sut.curve).to.eq(curve);
+          });
+          it(`${curve} Should return a public key if x is present`, async () => {
+            const sut = await new FromJWK({
+              jwk: fixTures[curve].public
+            }).run(ctx);
+
+            expect(sut).to.be.an.instanceOf(PublicKey);
+            expect(sut).toHaveProperty("curve");
+            expect(sut.curve).to.eq(curve);
+          });
         });
-
-        describe("EC Key type with secp256k1 curve", async () => {
-
-            it("Should throw an error if both coordinates and d are missing", async () => {
-                const sut = new FromJWK({
-                    jwk: {
-                        kty: "EC",
-                        crv: Curve.SECP256K1,
-                    }
-                }).run(ctx);
-                await expect(sut).rejects.toThrow("20: Required property x+y or d is missing in EC JWK");
-            });
-
-            it("Should throw an error if only one coordinate coordinate is present", async () => {
-                const sut = new FromJWK({
-                    jwk: {
-                        kty: "EC",
-                        crv: Curve.SECP256K1,
-                        x: "poDxfZtoOpBDtFqJmJ03_tei3ooCXrGXkJM_WUErZPM",
-                    }
-                }).run(ctx);
-                await expect(sut).rejects.toThrow("19: Missing JWK Parameter: y");
-
-                const sut2 = new FromJWK({
-                    jwk: {
-                        kty: "EC",
-                        crv: Curve.SECP256K1,
-                        y: "M6WTO1raVf2TNHO7t0IpiurajRo6k12HbJvNa2L-8sA",
-                    }
-                }).run(ctx);
-                await expect(sut2).rejects.toThrow("19: Missing JWK Parameter: x");
-            });
-
-            it("Should throw an error if d is present but invalid", async () => {
-                const sut = new FromJWK({
-                    jwk: {
-                        kty: "EC",
-                        crv: Curve.SECP256K1,
-                        d: "adsasdasdadsadsasd",
-                    }
-                }).run(ctx);
-                await expect(sut).rejects.toThrow("19: Invalid JWK Parameter, not base64url encoded: d");
-            });
-
-            it("Should throw an error if d is present but curve is unsupported", async () => {
-                const sut = new FromJWK({
-                    jwk: {
-                        kty: "EC",
-                        crv: "wrong curve",
-                        d: "adsasdasdadsadsasd",
-                    }
-                }).run(ctx);
-                await expect(sut).rejects.toThrow(ApolloError.InvalidKeyCurve)
-            });
-
-            it("Should throw an error if coordinate encoding is not valid", async () => {
-                const sut = new FromJWK({
-                    jwk: {
-                        kty: "EC",
-                        crv: Curve.SECP256K1,
-                        //Should be base64url encoded
-                        x: "1234567890",
-                        y: "1234567890"
-                    }
-                }).run(ctx);
-                await expect(sut).rejects.toThrow(PolluxError.InvalidJWKParameters);
-            });
-
-            it("Should not allow restoring from coordinates for non secp256k1 curves", async () => {
-                const sut = new FromJWK({
-                    jwk: {
-                        kty: "EC",
-                        crv: Curve.ED25519,
-                        x: "poDxfZtoOpBDtFqJmJ03_tei3ooCXrGXkJM_WUErZPM",
-                        y: "M6WTO1raVf2TNHO7t0IpiurajRo6k12HbJvNa2L-8sA",
-                    }
-                }).run(ctx);
-                await expect(sut).rejects.toThrow("16: Invalid key curve: Ed25519. Valid options are: secp256k1")
-            });
-
-            it("Should allow to recover a public key from x and y coordinates", async () => {
-                const sut = await new FromJWK({
-                    jwk: {
-                        kty: "EC",
-                        crv: Curve.SECP256K1,
-                        x: "poDxfZtoOpBDtFqJmJ03_tei3ooCXrGXkJM_WUErZPM",
-                        y: "M6WTO1raVf2TNHO7t0IpiurajRo6k12HbJvNa2L-8sA",
-                    }
-                }).run(ctx);
-                expect(sut).to.be.an.instanceOf(Secp256k1PublicKey);
-            });
-
-            it("Should allow to recover a keyPair key from x and y coordinates and d private key", async () => {
-                const sut = await new FromJWK({
-                    jwk: {
-                        kty: "EC",
-                        crv: Curve.SECP256K1,
-                        d: "ZLc6z-hpXb7RjPEve9rf-v44ElZJ-NQ5r0lqY-NpCuA",
-                        x: "wYMtiI5wJqztx6ywMtm9ns8Pnlsq7_ZMj_gJh9DXiL0",
-                        y: "g2p7eYiPxPMlZHQE95uV91gnwCMnOozpctwOPWzTCsM",
-                    }
-                }).run(ctx);
-
-                expect(sut).toHaveProperty("privateKey");
-                expect(sut).toHaveProperty("publicKey");
-
-                expect((sut as Domain.KeyPair).privateKey).to.be.an.instanceOf(Secp256k1PrivateKey);
-                expect((sut as Domain.KeyPair).publicKey).to.be.an.instanceOf(Secp256k1PublicKey);
-            });
-
-        });
-
-
-
-
-        describe("OKP Key type", async () => {
-
-            const supportedCurves = [Curve.ED25519, Curve.X25519];
-            const fixTures: Record<string, { private: JWK.OKP, public: JWK.OKP }> = {
-                [Curve.ED25519]: {
-                    private: {
-                        "kty": "OKP",
-                        "d": "c3sPtGX-Jy4Ayi1RUz27UIS4ztWSEfJdQ3etgsjBl5M",
-                        "crv": "Ed25519",
-                        "x": "j7J_Y6I6Qg0RRFmBw5kJhxj9IsYrLw57c0NTeh5WNiI",
-                        "alg": "EdDSA"
-                    },
-                    public: {
-                        "kty": "OKP",
-                        "crv": "Ed25519",
-                        "x": "j7J_Y6I6Qg0RRFmBw5kJhxj9IsYrLw57c0NTeh5WNiI",
-                        "alg": "EdDSA"
-                    }
-                },
-                [Curve.X25519]: {
-                    private: {
-                        "kty": "OKP",
-                        "d": "jZ52YidJvBz6GUroCIvasKSIAUrfp5Nk59zaM8biVIw",
-                        "crv": "X25519",
-                        "x": "eKj9zIA32kZc9jwSGnix2i8aiJo-ovrB8FeJkFwpMBE",
-                        "alg": "EdDSA"
-                    },
-                    public: {
-                        "kty": "OKP",
-                        "crv": "X25519",
-                        "x": "eKj9zIA32kZc9jwSGnix2i8aiJo-ovrB8FeJkFwpMBE",
-                        "alg": "EdDSA"
-                    }
-                }
-            }
-
-            it("Should throw an error if the curve is not supported", async () => {
-                const sut = new FromJWK({
-                    jwk: {
-                        ...fixTures[Curve.ED25519].public,
-                        crv: "wrong curve",
-                        x: undefined
-                    } as any
-                }).run(ctx);
-                await expect(sut).rejects.toThrow("16: Invalid key curve: wrong curve. Valid options are: X25519, Ed25519, secp256k1")
-            });
-
-
-            supportedCurves.forEach(curve => {
-                describe(`${curve} curve`, () => {
-                    it(`${curve} Should throw an error if x is missing`, async () => {
-                        const sut = new FromJWK({
-                            jwk: {
-                                ...fixTures[curve].public,
-                                x: undefined
-                            } as any
-                        }).run(ctx);
-                        await expect(sut).rejects.toThrow("19: Missing JWK Parameter x")
-                    })
-
-                    it(`${curve} Should throw an error if x is not encoded with base64url`, async () => {
-                        const sut = new FromJWK({
-                            jwk: {
-                                ...fixTures[curve].public,
-                                x: 'no'
-                            } as any
-                        }).run(ctx);
-                        await expect(sut).rejects.toThrow("19: Invalid JWK Parameter, not base64url encoded: x")
-                    })
-                    it(`${curve} Should throw an error if d property is not encoded with base64url`, async () => {
-                        const sut = new FromJWK({
-                            jwk: {
-                                ...fixTures[curve].private,
-                                d: 'no'
-                            } as any
-                        }).run(ctx);
-                        await expect(sut).rejects.toThrow("19: Invalid JWK Parameter, not base64url encoded: d")
-                    })
-                    it(`${curve} Should return a keyPair if x and d are present`, async () => {
-                        const sut = await new FromJWK({
-                            jwk: fixTures[curve].private
-                        }).run(ctx);
-
-                        expect(sut).toHaveProperty("privateKey");
-                        expect(sut).toHaveProperty("publicKey");
-                        expect(sut).toHaveProperty("curve");
-                        expect((sut as Domain.KeyPair).privateKey).to.be.an.instanceOf(PrivateKey);
-                        expect((sut as Domain.KeyPair).publicKey).to.be.an.instanceOf(PublicKey);
-                        expect(sut.curve).to.eq(curve)
-                    })
-                    it(`${curve} Should return a public key if x is present`, async () => {
-                        const sut = await new FromJWK({
-                            jwk: fixTures[curve].public
-                        }).run(ctx);
-
-                        expect(sut).to.be.an.instanceOf(PublicKey);
-                        expect(sut).toHaveProperty("curve");
-                        expect(sut.curve).to.eq(curve)
-                    })
-                });
-            });
-        });
+      });
     });
+  });
 
-})
+});

--- a/tests/pollux/JWT.test.ts
+++ b/tests/pollux/JWT.test.ts
@@ -16,7 +16,7 @@ describe("Domain - JWT", () => {
     apollo = new Apollo();
     castor = new Castor(apollo);
     plutoMock = { getDIDPrivateKeysByDID: vi.fn() } as any;
-    const ctx = Task.Context.make({
+    const ctx = new Task.Context({
       Apollo: apollo,
       Castor: castor,
       Pluto: plutoMock,

--- a/tests/pollux/JWTCredential.test.ts
+++ b/tests/pollux/JWTCredential.test.ts
@@ -14,7 +14,7 @@ describe("JWTCredential", () => {
   beforeEach(() => {
     apollo = new Apollo();
     castor = new Castor(apollo);
-    const ctx = Task.Context.make({
+    const ctx = new Task.Context({
       Apollo: apollo,
       Castor: castor,
     });

--- a/tests/pollux/Pollux.revocation.test.ts
+++ b/tests/pollux/Pollux.revocation.test.ts
@@ -26,624 +26,624 @@ const revocableJWTCredential = `eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiJkaWQ6cHJpc206Y
 vi.mock("pako");
 
 describe("Pollux", () => {
-    let api: Api;
-    let apollo: Apollo;
-    let plugins: PluginManager;
-    let testCtx: Task.Context<any>;
+  let api: Api;
+  let apollo: Apollo;
+  let plugins: PluginManager;
+  let testCtx: Task.Context<any>;
 
-    beforeEach(async () => {
-        const pakoPkg = await import('pako');
-        (pakoPkg as any).ungzip = (await vi.importActual('pako')).ungzip;
+  beforeEach(async () => {
+    const pakoPkg = await import('pako');
+    (pakoPkg as any).ungzip = (await vi.importActual('pako')).ungzip;
 
-        api = { request: async () => new ApiResponse<any>(new Uint8Array(), 200) };
-        apollo = new Apollo();
-        plugins = new PluginManager();
-        plugins.register(DIFPlugin);
-        testCtx = Task.Context.make({
-          Api: api,
-          Apollo: apollo,
-          Plugins: plugins,
-        });
+    api = { request: async () => new ApiResponse<any>(new Uint8Array(), 200) };
+    apollo = new Apollo();
+    plugins = new PluginManager();
+    plugins.register(DIFPlugin);
+    testCtx = new Task.Context({
+      Api: api,
+      Apollo: apollo,
+      Plugins: plugins,
     });
+  });
 
-    afterEach(async () => {
-      vi.restoreAllMocks();
-    });
+  afterEach(async () => {
+    vi.restoreAllMocks();
+  });
 
-    it("Should correctly determine that a Credential is revoked when calling the credentialStatus [EcdsaSecp256k1Signature2019] list endpoints", async () => {
-        vi.spyOn(api, "request").mockResolvedValue(new ApiResponse({
-                "proof": {
-                    "type": "EcdsaSecp256k1Signature2019",
-                    "proofPurpose": "assertionMethod",
-                    "verificationMethod": "data:application/json;base64,eyJAY29udGV4dCI6WyJodHRwczovL3czaWQub3JnL3NlY3VyaXR5L3YxIl0sInR5cGUiOiJFY2RzYVNlY3AyNTZrMVZlcmlmaWNhdGlvbktleTIwMTkiLCJwdWJsaWNLZXlKd2siOnsiY3J2Ijoic2VjcDI1NmsxIiwia2V5X29wcyI6WyJ2ZXJpZnkiXSwia3R5IjoiRUMiLCJ4IjoiQ1hJRmwyUjE4YW1lTEQteWtTT0dLUW9DQlZiRk01b3Vsa2MydklySnRTND0iLCJ5IjoiRDJRWU5pNi1BOXoxbHhwUmpLYm9jS1NUdk5BSXNOVnNsQmpsemVnWXlVQT0ifX0=",
-                    "created": "2024-07-25T22:49:59.091957Z",
-                    "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..FJLUBsZhGB1o_G1UwsVaoL-8agvcpoelJtAr2GlNOOqCSOd-WNEj5-FOgv0m0QcdKMokl2TxibJMg3Y-MJq4-A"
-                },
-                "@context": [
-                    "https://www.w3.org/2018/credentials/v1",
-                    "https://w3id.org/vc/status-list/2021/v1"
-                ],
-                "type": [
-                    "VerifiableCredential",
-                    "StatusList2021Credential"
-                ],
-                "id": "http://localhost:8085/credential-status/01def9a2-2bcb-4bb3-8a36-6834066431d0",
-                "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
-                "issuanceDate": 1721947798,
-                "credentialSubject": {
-                    "type": "StatusList2021",
-                    "statusPurpose": "Revocation",
-                    "encodedList": "H4sIAAAAAAAA_-3BIQEAAAACIKf6f4UzLEADAAAAAAAAAAAAAAAAAAAAvA3PduITAEAAAA=="
-                }
-            }, 200)
-        );
+  it("Should correctly determine that a Credential is revoked when calling the credentialStatus [EcdsaSecp256k1Signature2019] list endpoints", async () => {
+    vi.spyOn(api, "request").mockResolvedValue(new ApiResponse({
+      "proof": {
+        "type": "EcdsaSecp256k1Signature2019",
+        "proofPurpose": "assertionMethod",
+        "verificationMethod": "data:application/json;base64,eyJAY29udGV4dCI6WyJodHRwczovL3czaWQub3JnL3NlY3VyaXR5L3YxIl0sInR5cGUiOiJFY2RzYVNlY3AyNTZrMVZlcmlmaWNhdGlvbktleTIwMTkiLCJwdWJsaWNLZXlKd2siOnsiY3J2Ijoic2VjcDI1NmsxIiwia2V5X29wcyI6WyJ2ZXJpZnkiXSwia3R5IjoiRUMiLCJ4IjoiQ1hJRmwyUjE4YW1lTEQteWtTT0dLUW9DQlZiRk01b3Vsa2MydklySnRTND0iLCJ5IjoiRDJRWU5pNi1BOXoxbHhwUmpLYm9jS1NUdk5BSXNOVnNsQmpsemVnWXlVQT0ifX0=",
+        "created": "2024-07-25T22:49:59.091957Z",
+        "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..FJLUBsZhGB1o_G1UwsVaoL-8agvcpoelJtAr2GlNOOqCSOd-WNEj5-FOgv0m0QcdKMokl2TxibJMg3Y-MJq4-A"
+      },
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://w3id.org/vc/status-list/2021/v1"
+      ],
+      "type": [
+        "VerifiableCredential",
+        "StatusList2021Credential"
+      ],
+      "id": "http://localhost:8085/credential-status/01def9a2-2bcb-4bb3-8a36-6834066431d0",
+      "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
+      "issuanceDate": 1721947798,
+      "credentialSubject": {
+        "type": "StatusList2021",
+        "statusPurpose": "Revocation",
+        "encodedList": "H4sIAAAAAAAA_-3BIQEAAAACIKf6f4UzLEADAAAAAAAAAAAAAAAAAAAAvA3PduITAEAAAA=="
+      }
+    }, 200)
+    );
 
-        const credential = JWTCredential.fromJWS(revocableJWTCredential);
-        const credential2 = JWTCredential.fromJWS(revocableJWTCredential);
-        const credential3 = JWTCredential.fromJWS(revocableJWTCredential);
+    const credential = JWTCredential.fromJWS(revocableJWTCredential);
+    const credential2 = JWTCredential.fromJWS(revocableJWTCredential);
+    const credential3 = JWTCredential.fromJWS(revocableJWTCredential);
 
-        const vc = credential.properties.get(JWT_VC_PROPS.vc);
-        vc.credentialStatus.statusListIndex = 1;
-        credential.properties.set(JWT_VC_PROPS.vc, vc);
+    const vc = credential.properties.get(JWT_VC_PROPS.vc);
+    vc.credentialStatus.statusListIndex = 1;
+    credential.properties.set(JWT_VC_PROPS.vc, vc);
 
-        const vc2 = credential2.properties.get(JWT_VC_PROPS.vc);
-        vc2.credentialStatus.statusListIndex = 2;
-        credential2.properties.set(JWT_VC_PROPS.vc, vc2);
+    const vc2 = credential2.properties.get(JWT_VC_PROPS.vc);
+    vc2.credentialStatus.statusListIndex = 2;
+    credential2.properties.set(JWT_VC_PROPS.vc, vc2);
 
-        const vc3 = credential3.properties.get(JWT_VC_PROPS.vc);
-        vc3.credentialStatus.statusListIndex = 3;
-        credential3.properties.set(JWT_VC_PROPS.vc, vc3);
+    const vc3 = credential3.properties.get(JWT_VC_PROPS.vc);
+    vc3.credentialStatus.statusListIndex = 3;
+    credential3.properties.set(JWT_VC_PROPS.vc, vc3);
 
-        const revoked = await testCtx.run(new RunProtocol({
-          type: "revocation-check",
-          pid: "prism/jwt",
-          data: { credential }
-        }));
+    const revoked = await testCtx.run(new RunProtocol({
+      type: "revocation-check",
+      pid: "prism/jwt",
+      data: { credential }
+    }));
 
-        const revoked2 = await testCtx.run(new RunProtocol({
-          type: "revocation-check",
-          pid: "prism/jwt",
-          data: { credential: credential2 }
-        }));
+    const revoked2 = await testCtx.run(new RunProtocol({
+      type: "revocation-check",
+      pid: "prism/jwt",
+      data: { credential: credential2 }
+    }));
 
-        const revoked3 = await testCtx.run(new RunProtocol({
-          type: "revocation-check",
-          pid: "prism/jwt",
-          data: { credential: credential3 }
-        }));
+    const revoked3 = await testCtx.run(new RunProtocol({
+      type: "revocation-check",
+      pid: "prism/jwt",
+      data: { credential: credential3 }
+    }));
 
-        expect(revoked.data).to.eq(true)
-        expect(revoked2.data).to.eq(true)
-        expect(revoked3.data).to.eq(false)
-    })
+    expect(revoked.data).to.eq(true);
+    expect(revoked2.data).to.eq(true);
+    expect(revoked3.data).to.eq(false);
+  });
 
-    it("Should throw an error if we try to use a SDJWT credential ", async () => {
-      vi.spyOn(api, "request").mockResolvedValue(new ApiResponse({
-                "proof": {
-                    "type": "EcdsaSecp256k1Signature2019",
-                    "proofPurpose": "assertionMethod",
-                    "verificationMethod": "data:application/json;base64,eyJAY29udGV4dCI6WyJodHRwczovL3czaWQub3JnL3NlY3VyaXR5L3YxIl0sInR5cGUiOiJFY2RzYVNlY3AyNTZrMVZlcmlmaWNhdGlvbktleTIwMTkiLCJwdWJsaWNLZXlKd2siOnsiY3J2Ijoic2VjcDI1NmsxIiwia2V5X29wcyI6WyJ2ZXJpZnkiXSwia3R5IjoiRUMiLCJ4IjoiVFlCZ21sM1RpUWRSX1lRRDFoSXVOTzhiUnluU0otcmxQcWFVd3JXa3EtRT0iLCJ5IjoiVjBnVFlBM0xhbFd3Q3hPZHlqb2ZoR2JkYVFEd3EwQXdCblNodFJLXzNYZz0ifX0=",
-                    "created": "2024-06-14T10:56:59.948091Z",
-                    "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..Q1mj3jMf5DWK83E55r6vNUPpsYYgclgwYoNFBSYBzA5x6fI_2cPHJsXECnQlG1XMj2ifldngpJXegTpwe3Fgwg"
-                },
-                "@context": [
-                    "https://www.w3.org/2018/credentials/v1",
-                    "https://w3id.org/vc/status-list/2021/v1"
-                ],
-                "type": [
-                    "VerifiableCredential",
-                    "StatusList2021Credential"
-                ],
-                "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
-                "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
-                "issuanceDate": 1717714047,
-                "credentialSubject": {
-                    "type": "StatusList2024",
-                    "statusPurpose": "Revocation",
-                    //Credential index [0] has a value of 2
-                    "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
-                }
-            }, 200)
-        );
-        const credential = SDJWTCredential.fromJWS(Fixtures.Credentials.SDJWT.credentialPayloadEncoded);
+  it("Should throw an error if we try to use a SDJWT credential ", async () => {
+    vi.spyOn(api, "request").mockResolvedValue(new ApiResponse({
+      "proof": {
+        "type": "EcdsaSecp256k1Signature2019",
+        "proofPurpose": "assertionMethod",
+        "verificationMethod": "data:application/json;base64,eyJAY29udGV4dCI6WyJodHRwczovL3czaWQub3JnL3NlY3VyaXR5L3YxIl0sInR5cGUiOiJFY2RzYVNlY3AyNTZrMVZlcmlmaWNhdGlvbktleTIwMTkiLCJwdWJsaWNLZXlKd2siOnsiY3J2Ijoic2VjcDI1NmsxIiwia2V5X29wcyI6WyJ2ZXJpZnkiXSwia3R5IjoiRUMiLCJ4IjoiVFlCZ21sM1RpUWRSX1lRRDFoSXVOTzhiUnluU0otcmxQcWFVd3JXa3EtRT0iLCJ5IjoiVjBnVFlBM0xhbFd3Q3hPZHlqb2ZoR2JkYVFEd3EwQXdCblNodFJLXzNYZz0ifX0=",
+        "created": "2024-06-14T10:56:59.948091Z",
+        "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..Q1mj3jMf5DWK83E55r6vNUPpsYYgclgwYoNFBSYBzA5x6fI_2cPHJsXECnQlG1XMj2ifldngpJXegTpwe3Fgwg"
+      },
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://w3id.org/vc/status-list/2021/v1"
+      ],
+      "type": [
+        "VerifiableCredential",
+        "StatusList2021Credential"
+      ],
+      "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
+      "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
+      "issuanceDate": 1717714047,
+      "credentialSubject": {
+        "type": "StatusList2024",
+        "statusPurpose": "Revocation",
+        //Credential index [0] has a value of 2
+        "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
+      }
+    }, 200)
+    );
+    const credential = SDJWTCredential.fromJWS(Fixtures.Credentials.SDJWT.credentialPayloadEncoded);
 
-        const sut = testCtx.run(new RunProtocol({
-          type: "revocation-check",
-          pid: "prism/jwt",
-          data: { credential }
-        }));
+    const sut = testCtx.run(new RunProtocol({
+      type: "revocation-check",
+      pid: "prism/jwt",
+      data: { credential }
+    }));
 
-        await expect(sut).to.eventually.rejectedWith(`Only JWT Credential are supported`)
-    })
+    await expect(sut).to.eventually.rejectedWith(`Only JWT Credential are supported`);
+  });
 
-    it("Should throw an error if we try to use a credential which an unsupported type ", async () => {
-        vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
-            {
-                "proof": {
-                    "type": "EcdsaSecp256k1Signature2019",
-                    "proofPurpose": "assertionMethod",
-                    "verificationMethod": "data:application/json;base64,eyJAY29udGV4dCI6WyJodHRwczovL3czaWQub3JnL3NlY3VyaXR5L3YxIl0sInR5cGUiOiJFY2RzYVNlY3AyNTZrMVZlcmlmaWNhdGlvbktleTIwMTkiLCJwdWJsaWNLZXlKd2siOnsiY3J2Ijoic2VjcDI1NmsxIiwia2V5X29wcyI6WyJ2ZXJpZnkiXSwia3R5IjoiRUMiLCJ4IjoiVFlCZ21sM1RpUWRSX1lRRDFoSXVOTzhiUnluU0otcmxQcWFVd3JXa3EtRT0iLCJ5IjoiVjBnVFlBM0xhbFd3Q3hPZHlqb2ZoR2JkYVFEd3EwQXdCblNodFJLXzNYZz0ifX0=",
-                    "created": "2024-06-14T10:56:59.948091Z",
-                    "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..Q1mj3jMf5DWK83E55r6vNUPpsYYgclgwYoNFBSYBzA5x6fI_2cPHJsXECnQlG1XMj2ifldngpJXegTpwe3Fgwg"
-                },
-                "@context": [
-                    "https://www.w3.org/2018/credentials/v1",
-                    "https://w3id.org/vc/status-list/2021/v1"
-                ],
-                "type": [
-                    "VerifiableCredential",
-                    "StatusList2021Credential"
-                ],
-                "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
-                "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
-                "issuanceDate": 1717714047,
-                "credentialSubject": {
-                    "type": "StatusList2024",
-                    "statusPurpose": "Revocation",
-                    //Credential index [0] has a value of 2
-                    "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
-                }
-              }, 200)
-        );
-        const credential = JWTCredential.fromJWS(revocableJWTCredential);
-        const vc = credential.properties.get(JWT_VC_PROPS.vc);
-        vc.credentialStatus.statusListIndex = 0;
-        vc.credentialStatus.type = "Wrong"
-        credential.properties.set(JWT_VC_PROPS.vc, vc);
+  it("Should throw an error if we try to use a credential which an unsupported type ", async () => {
+    vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
+      {
+        "proof": {
+          "type": "EcdsaSecp256k1Signature2019",
+          "proofPurpose": "assertionMethod",
+          "verificationMethod": "data:application/json;base64,eyJAY29udGV4dCI6WyJodHRwczovL3czaWQub3JnL3NlY3VyaXR5L3YxIl0sInR5cGUiOiJFY2RzYVNlY3AyNTZrMVZlcmlmaWNhdGlvbktleTIwMTkiLCJwdWJsaWNLZXlKd2siOnsiY3J2Ijoic2VjcDI1NmsxIiwia2V5X29wcyI6WyJ2ZXJpZnkiXSwia3R5IjoiRUMiLCJ4IjoiVFlCZ21sM1RpUWRSX1lRRDFoSXVOTzhiUnluU0otcmxQcWFVd3JXa3EtRT0iLCJ5IjoiVjBnVFlBM0xhbFd3Q3hPZHlqb2ZoR2JkYVFEd3EwQXdCblNodFJLXzNYZz0ifX0=",
+          "created": "2024-06-14T10:56:59.948091Z",
+          "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..Q1mj3jMf5DWK83E55r6vNUPpsYYgclgwYoNFBSYBzA5x6fI_2cPHJsXECnQlG1XMj2ifldngpJXegTpwe3Fgwg"
+        },
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://w3id.org/vc/status-list/2021/v1"
+        ],
+        "type": [
+          "VerifiableCredential",
+          "StatusList2021Credential"
+        ],
+        "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
+        "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
+        "issuanceDate": 1717714047,
+        "credentialSubject": {
+          "type": "StatusList2024",
+          "statusPurpose": "Revocation",
+          //Credential index [0] has a value of 2
+          "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
+        }
+      }, 200)
+    );
+    const credential = JWTCredential.fromJWS(revocableJWTCredential);
+    const vc = credential.properties.get(JWT_VC_PROPS.vc);
+    vc.credentialStatus.statusListIndex = 0;
+    vc.credentialStatus.type = "Wrong";
+    credential.properties.set(JWT_VC_PROPS.vc, vc);
 
-        const sut = testCtx.run(new RunProtocol({
-          type: "revocation-check",
-          pid: "prism/jwt",
-          data: { credential }
-        }));
+    const sut = testCtx.run(new RunProtocol({
+      type: "revocation-check",
+      pid: "prism/jwt",
+      data: { credential }
+    }));
 
-        await expect(sut).to.eventually.rejectedWith(`CredentialStatus revocation type not supported`)
+    await expect(sut).to.eventually.rejectedWith(`CredentialStatus revocation type not supported`);
 
-        const sut2 = testCtx.run(new RunProtocol({
-          type: "revocation-check",
-          pid: "prism/jwt",
-          data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
-        }));
-        
-        await expect(sut2).to.eventually.rejectedWith(`CredentialStatus response revocation type not supported`)
-    })
+    const sut2 = testCtx.run(new RunProtocol({
+      type: "revocation-check",
+      pid: "prism/jwt",
+      data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
+    }));
 
-    it("Should throw an error if the credential status proof contains an invalid verificationMethod", async () => {
+    await expect(sut2).to.eventually.rejectedWith(`CredentialStatus response revocation type not supported`);
+  });
 
-        vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
-            {
-                "proof": {
-                    "type": "EcdsaSecp256k1Signature2019",
-                    "proofPurpose": "assertionMethod",
-                    "verificationMethod": "data:application/json;base64",
-                    "created": "2024-06-14T10:56:59.948091Z",
-                    "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..Q1mj3jMf5DWK83E55r6vNUPpsYYgclgwYoNFBSYBzA5x6fI_2cPHJsXECnQlG1XMj2ifldngpJXegTpwe3Fgwg"
-                },
-                "@context": [
-                    "https://www.w3.org/2018/credentials/v1",
-                    "https://w3id.org/vc/status-list/2021/v1"
-                ],
-                "type": [
-                    "VerifiableCredential",
-                    "StatusList2021Credential"
-                ],
-                "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
-                "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
-                "issuanceDate": 1717714047,
-                "credentialSubject": {
-                    "type": "StatusList2021",
-                    "statusPurpose": "Revocation",
-                    "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
-                }
-              }, 200)
-        );
+  it("Should throw an error if the credential status proof contains an invalid verificationMethod", async () => {
 
-        const sut = testCtx.run(new RunProtocol({
-          type: "revocation-check",
-          pid: "prism/jwt",
-          data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
-        }));
+    vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
+      {
+        "proof": {
+          "type": "EcdsaSecp256k1Signature2019",
+          "proofPurpose": "assertionMethod",
+          "verificationMethod": "data:application/json;base64",
+          "created": "2024-06-14T10:56:59.948091Z",
+          "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..Q1mj3jMf5DWK83E55r6vNUPpsYYgclgwYoNFBSYBzA5x6fI_2cPHJsXECnQlG1XMj2ifldngpJXegTpwe3Fgwg"
+        },
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://w3id.org/vc/status-list/2021/v1"
+        ],
+        "type": [
+          "VerifiableCredential",
+          "StatusList2021Credential"
+        ],
+        "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
+        "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
+        "issuanceDate": 1717714047,
+        "credentialSubject": {
+          "type": "StatusList2021",
+          "statusPurpose": "Revocation",
+          "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
+        }
+      }, 200)
+    );
 
-        await expect(sut)
-            .to.eventually.rejectedWith(`CredentialStatus proof invalid verificationMethod`)
+    const sut = testCtx.run(new RunProtocol({
+      type: "revocation-check",
+      pid: "prism/jwt",
+      data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
+    }));
 
-    })
+    await expect(sut)
+      .to.eventually.rejectedWith(`CredentialStatus proof invalid verificationMethod`);
 
-    it("should throw an error if no jwk is provided", async () => {
-        const encoded = base64.baseEncode(Buffer.from(JSON.stringify({ noJWK: true })))
-        vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
-            {
-                "proof": {
-                    "type": "EcdsaSecp256k1Signature2019",
-                    "proofPurpose": "assertionMethod",
-                    "verificationMethod": `data:application/json;base64,${encoded}`,
-                    "created": "2024-06-14T10:56:59.948091Z",
-                    "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..Q1mj3jMf5DWK83E55r6vNUPpsYYgclgwYoNFBSYBzA5x6fI_2cPHJsXECnQlG1XMj2ifldngpJXegTpwe3Fgwg"
-                },
-                "@context": [
-                    "https://www.w3.org/2018/credentials/v1",
-                    "https://w3id.org/vc/status-list/2021/v1"
-                ],
-                "type": [
-                    "VerifiableCredential",
-                    "StatusList2021Credential"
-                ],
-                "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
-                "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
-                "issuanceDate": 1717714047,
-                "credentialSubject": {
-                    "type": "StatusList2021",
-                    "statusPurpose": "Revocation",
-                    "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
-                }
-              }, 200)
-        );
+  });
 
-        const sut = testCtx.run(new RunProtocol({
-          type: "revocation-check",
-          pid: "prism/jwt",
-          data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
-        }));
+  it("should throw an error if no jwk is provided", async () => {
+    const encoded = base64.baseEncode(Buffer.from(JSON.stringify({ noJWK: true })));
+    vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
+      {
+        "proof": {
+          "type": "EcdsaSecp256k1Signature2019",
+          "proofPurpose": "assertionMethod",
+          "verificationMethod": `data:application/json;base64,${encoded}`,
+          "created": "2024-06-14T10:56:59.948091Z",
+          "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..Q1mj3jMf5DWK83E55r6vNUPpsYYgclgwYoNFBSYBzA5x6fI_2cPHJsXECnQlG1XMj2ifldngpJXegTpwe3Fgwg"
+        },
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://w3id.org/vc/status-list/2021/v1"
+        ],
+        "type": [
+          "VerifiableCredential",
+          "StatusList2021Credential"
+        ],
+        "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
+        "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
+        "issuanceDate": 1717714047,
+        "credentialSubject": {
+          "type": "StatusList2021",
+          "statusPurpose": "Revocation",
+          "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
+        }
+      }, 200)
+    );
 
-        await expect(sut)
-            .to.eventually.rejectedWith("No public jwk provided")
-    })
+    const sut = testCtx.run(new RunProtocol({
+      type: "revocation-check",
+      pid: "prism/jwt",
+      data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
+    }));
 
-    it("should throw an eror if a wrong verificationMethod type is used", async () => {
-        const encoded2 = base64.baseEncode(Buffer.from(JSON.stringify({ publicKeyJwk: { x: "423", y: "123" } })))
-        vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
-            {
-                "proof": {
-                    "type": "EcdsaSecp256k1Signature2019",
-                    "proofPurpose": "assertionMethod",
-                    "verificationMethod": `data:application/json;base64,${encoded2}`,
-                    "created": "2024-06-14T10:56:59.948091Z",
-                    "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..Q1mj3jMf5DWK83E55r6vNUPpsYYgclgwYoNFBSYBzA5x6fI_2cPHJsXECnQlG1XMj2ifldngpJXegTpwe3Fgwg"
-                },
-                "@context": [
-                    "https://www.w3.org/2018/credentials/v1",
-                    "https://w3id.org/vc/status-list/2021/v1"
-                ],
-                "type": [
-                    "VerifiableCredential",
-                    "StatusList2021Credential"
-                ],
-                "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
-                "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
-                "issuanceDate": 1717714047,
-                "credentialSubject": {
-                    "type": "StatusList2021",
-                    "statusPurpose": "Revocation",
-                    "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
-                }
-              }, 200)
-        );
+    await expect(sut)
+      .to.eventually.rejectedWith("No public jwk provided");
+  });
 
-        const sut = testCtx.run(new RunProtocol({
-          type: "revocation-check",
-          pid: "prism/jwt",
-          data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
-        }));
+  it("should throw an eror if a wrong verificationMethod type is used", async () => {
+    const encoded2 = base64.baseEncode(Buffer.from(JSON.stringify({ publicKeyJwk: { x: "423", y: "123" } })));
+    vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
+      {
+        "proof": {
+          "type": "EcdsaSecp256k1Signature2019",
+          "proofPurpose": "assertionMethod",
+          "verificationMethod": `data:application/json;base64,${encoded2}`,
+          "created": "2024-06-14T10:56:59.948091Z",
+          "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..Q1mj3jMf5DWK83E55r6vNUPpsYYgclgwYoNFBSYBzA5x6fI_2cPHJsXECnQlG1XMj2ifldngpJXegTpwe3Fgwg"
+        },
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://w3id.org/vc/status-list/2021/v1"
+        ],
+        "type": [
+          "VerifiableCredential",
+          "StatusList2021Credential"
+        ],
+        "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
+        "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
+        "issuanceDate": 1717714047,
+        "credentialSubject": {
+          "type": "StatusList2021",
+          "statusPurpose": "Revocation",
+          "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
+        }
+      }, 200)
+    );
 
-        await expect(sut)
-            .to.eventually.rejectedWith("Err Only EcdsaSecp256k1VerificationKey2019 is supported")
+    const sut = testCtx.run(new RunProtocol({
+      type: "revocation-check",
+      pid: "prism/jwt",
+      data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
+    }));
 
-
-    })
-
-    it("Should throw an error if a wrong key type is used", async () => {
-        const encoded3 = base64.baseEncode(Buffer.from(JSON.stringify({ type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019, publicKeyJwk: { x: "423", y: "123" } })))
-        vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
-            {
-                "proof": {
-                    "type": "EcdsaSecp256k1Signature2019",
-                    "proofPurpose": "assertionMethod",
-                    "verificationMethod": `data:application/json;base64,${encoded3}`,
-                    "created": "2024-06-14T10:56:59.948091Z",
-                    "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..Q1mj3jMf5DWK83E55r6vNUPpsYYgclgwYoNFBSYBzA5x6fI_2cPHJsXECnQlG1XMj2ifldngpJXegTpwe3Fgwg"
-                },
-                "@context": [
-                    "https://www.w3.org/2018/credentials/v1",
-                    "https://w3id.org/vc/status-list/2021/v1"
-                ],
-                "type": [
-                    "VerifiableCredential",
-                    "StatusList2021Credential"
-                ],
-                "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
-                "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
-                "issuanceDate": 1717714047,
-                "credentialSubject": {
-                    "type": "StatusList2021",
-                    "statusPurpose": "Revocation",
-                    "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
-                }
-              }, 200)
-        );
-
-        const sut = testCtx.run(new RunProtocol({
-          type: "revocation-check",
-          pid: "prism/jwt",
-          data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
-        }));
-
-        await expect(sut)
-            .to.eventually.rejectedWith("Err Invalid JWK kty: undefined, should be EC")
-
-    })
-
-    it("Should throw an error if a wrong key curve is used", async () => {
-        const encoded4 = base64.baseEncode(Buffer.from(JSON.stringify({ type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019, publicKeyJwk: { x: "423", y: "123", kty: KeyTypes.EC } })))
-        vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
-            {
-                "proof": {
-                    "type": "EcdsaSecp256k1Signature2019",
-                    "proofPurpose": "assertionMethod",
-                    "verificationMethod": `data:application/json;base64,${encoded4}`,
-                    "created": "2024-06-14T10:56:59.948091Z",
-                    "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..Q1mj3jMf5DWK83E55r6vNUPpsYYgclgwYoNFBSYBzA5x6fI_2cPHJsXECnQlG1XMj2ifldngpJXegTpwe3Fgwg"
-                },
-                "@context": [
-                    "https://www.w3.org/2018/credentials/v1",
-                    "https://w3id.org/vc/status-list/2021/v1"
-                ],
-                "type": [
-                    "VerifiableCredential",
-                    "StatusList2021Credential"
-                ],
-                "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
-                "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
-                "issuanceDate": 1717714047,
-                "credentialSubject": {
-                    "type": "StatusList2021",
-                    "statusPurpose": "Revocation",
-                    "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
-                }
-              }, 200)
-        );
-
-        const sut = testCtx.run(new RunProtocol({
-          type: "revocation-check",
-          pid: "prism/jwt",
-          data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
-        }));
-
-        await expect(sut)
-            .to.eventually.rejectedWith("Err Invalid JWK crv: undefined, should be secp256k1")
-    })
-
-    it("Should throw an eror if an invalid verificationKey is used", async () => {
-        const encoded5 = base64.baseEncode(Buffer.from(JSON.stringify({ type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019, publicKeyJwk: { x: 'TYBgml3TiQdR_YQD1hIuNO8bRynSJ-rlPqaUwrWkq-E=', y: 'V0gTYA3LalWwCxOdyjofhGbdaQDwq0AwBnShtRK_3Xg=', kty: KeyTypes.EC, crv: Curve.SECP256K1.toLocaleLowerCase() } })))
-        const pk = { ...Fixtures.Keys.secp256K1.publicKey } as any;
-
-        pk.canVerify = () => false;
-        vi.spyOn(apollo, "createPublicKey").mockReturnValue(pk);
-
-        vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
-            {
-                "proof": {
-                    "type": "EcdsaSecp256k1Signature2019",
-                    "proofPurpose": "assertionMethod",
-                    "verificationMethod": `data:application/json;base64,${encoded5}`,
-                    "created": "2024-06-14T10:56:59.948091Z",
-                    "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..Q1mj3jMf5DWK83E55r6vNUPpsYYgclgwYoNFBSYBzA5x6fI_2cPHJsXECnQlG1XMj2ifldngpJXegTpwe3Fgwg"
-                },
-                "@context": [
-                    "https://www.w3.org/2018/credentials/v1",
-                    "https://w3id.org/vc/status-list/2021/v1"
-                ],
-                "type": [
-                    "VerifiableCredential",
-                    "StatusList2021Credential"
-                ],
-                "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
-                "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
-                "issuanceDate": 1717714047,
-                "credentialSubject": {
-                    "type": "StatusList2021",
-                    "statusPurpose": "Revocation",
-                    "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
-                }
-              }, 200)
-        );
-
-        const sut = testCtx.run(new RunProtocol({
-          type: "revocation-check",
-          pid: "prism/jwt",
-          data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
-        }));
-
-        await expect(sut)
-            .to.eventually.rejectedWith("CredentialStatus proof invalid verifying key")
-    })
-
-    it("Should throw an error if the status jwt is invalid", async () => {
-        const encoded6 = base64.baseEncode(Buffer.from(JSON.stringify({ type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019, publicKeyJwk: { x: 'TYBgml3TiQdR_YQD1hIuNO8bRynSJ-rlPqaUwrWkq-E=', y: 'V0gTYA3LalWwCxOdyjofhGbdaQDwq0AwBnShtRK_3Xg=', kty: KeyTypes.EC, crv: Curve.SECP256K1.toLocaleLowerCase() } })))
-
-        vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
-            {
-                "proof": {
-                    "type": "EcdsaSecp256k1Signature2019",
-                    "proofPurpose": "assertionMethod",
-                    "verificationMethod": `data:application/json;base64,${encoded6}`,
-                    "created": "2024-06-14T10:56:59.948091Z",
-                    "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ."
-                },
-                "@context": [
-                    "https://www.w3.org/2018/credentials/v1",
-                    "https://w3id.org/vc/status-list/2021/v1"
-                ],
-                "type": [
-                    "VerifiableCredential",
-                    "StatusList2021Credential"
-                ],
-                "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
-                "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
-                "issuanceDate": 1717714047,
-                "credentialSubject": {
-                    "type": "StatusList2021",
-                    "statusPurpose": "Revocation",
-                    "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
-                }
-              }, 200)
-        );
-
-        const sut = testCtx.run(new RunProtocol({
-          type: "revocation-check",
-          pid: "prism/jwt",
-          data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
-        }));
-
-        await expect(sut)
-            .to.eventually.rejectedWith("Credential status jwt is invalid")
-    })
-
-    it("should throw an error if wrong signature is used", async () => {
-        const pk2 = { ...Fixtures.Keys.secp256K1.publicKey } as any;
-        (pk2 as any).verify = () => false;
-        (pk2 as any).canVerify = () => true;
-        const encoded8 = base64.baseEncode(
-            Buffer.from(
-                JSON.stringify({
-                    type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019,
-                    publicKeyJwk: {
-                        x: 'TYBgml3TiQdR_YQD1hIuNO8bRynSJ-rlPqaUwrWkq-E=',
-                        y: 'V0gTYA3LalWwCxOdyjofhGbdaQDwq0AwBnShtRK_3Xg=',
-                        kty: KeyTypes.EC,
-                        crv: Curve.SECP256K1.toLocaleLowerCase()
-                    }
-                }
-                )
-            )
-        );
-
-        vi.spyOn(apollo, "createPublicKey").mockReturnValue(pk2);
-
-        vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
-            {
-                "proof": {
-                    "type": "EcdsaSecp256k1Signature2019",
-                    "proofPurpose": "assertionMethod",
-                    "verificationMethod": `data:application/json;base64,${encoded8}`,
-                    "created": "2024-06-14T10:56:59.948091Z",
-                    "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..Q1mj3jMf5DWK83E55r6vNUPpsYYgclgwYoNFBSYBzA5x6fI_2cPHJsXECnQlG1XMj2ifldngpJXegTpwe3Fgwg"
-                },
-                "@context": [
-                    "https://www.w3.org/2018/credentials/v1",
-                    "https://w3id.org/vc/status-list/2021/v1"
-                ],
-                "type": [
-                    "VerifiableCredential",
-                    "StatusList2021Credential"
-                ],
-                "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
-                "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
-                "issuanceDate": 1717714047,
-                "credentialSubject": {
-                    "type": "StatusList2021",
-                    "statusPurpose": "Revocation",
-                    "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
-                }
-              }, 200)
-        );
-
-        const sut = testCtx.run(new RunProtocol({
-          type: "revocation-check",
-          pid: "prism/jwt",
-          data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
-        }));
-
-        await expect(sut)
-            .to.eventually.rejectedWith("CredentialStatus invalid signature")
-    })
-
-    it("Should throw an error if we cannot decode the revocation registry correctly ", async () => {
-        const pakoPkg = await import('pako');
-        // (pakoPkg as any).ungzip = vi.fn().mockImplementation(() => { throw new Error('whatever'); });
-
-        // (await vi.importActual('pako')).ungzip;
-
-        // const pako = await import("pako");
-        const spy = vi.spyOn(pakoPkg, "ungzip").mockImplementation(() => { throw new Error('whatever'); });
-        // vi.mocked(pako.ungzip).mockImplementation(() => { throw new Error('whatever'); })
+    await expect(sut)
+      .to.eventually.rejectedWith("Err Only EcdsaSecp256k1VerificationKey2019 is supported");
 
 
-        vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
-            {
-                "proof": {
-                    "type": "EcdsaSecp256k1Signature2019",
-                    "proofPurpose": "assertionMethod",
-                    "verificationMethod": "data:application/json;base64,eyJAY29udGV4dCI6WyJodHRwczovL3czaWQub3JnL3NlY3VyaXR5L3YxIl0sInR5cGUiOiJFY2RzYVNlY3AyNTZrMVZlcmlmaWNhdGlvbktleTIwMTkiLCJwdWJsaWNLZXlKd2siOnsiY3J2Ijoic2VjcDI1NmsxIiwia2V5X29wcyI6WyJ2ZXJpZnkiXSwia3R5IjoiRUMiLCJ4IjoiVFlCZ21sM1RpUWRSX1lRRDFoSXVOTzhiUnluU0otcmxQcWFVd3JXa3EtRT0iLCJ5IjoiVjBnVFlBM0xhbFd3Q3hPZHlqb2ZoR2JkYVFEd3EwQXdCblNodFJLXzNYZz0ifX0=",
-                    "created": "2024-06-14T10:56:59.948091Z",
-                    "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..Q1mj3jMf5DWK83E55r6vNUPpsYYgclgwYoNFBSYBzA5x6fI_2cPHJsXECnQlG1XMj2ifldngpJXegTpwe3Fgwg"
-                },
-                "@context": [
-                    "https://www.w3.org/2018/credentials/v1",
-                    "https://w3id.org/vc/status-list/2021/v1"
-                ],
-                "type": [
-                    "VerifiableCredential",
-                    "StatusList2021Credential"
-                ],
-                "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
-                "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
-                "issuanceDate": 1717714047,
-                "credentialSubject": {
-                    "type": "StatusList2021",
-                    "statusPurpose": "Revocation",
-                    "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
-                }
-              }, 200)
-        );
+  });
 
-        const sut = testCtx.run(new RunProtocol({
-          type: "revocation-check",
-          pid: "prism/jwt",
-          data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
-        }));
+  it("Should throw an error if a wrong key type is used", async () => {
+    const encoded3 = base64.baseEncode(Buffer.from(JSON.stringify({ type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019, publicKeyJwk: { x: "423", y: "123" } })));
+    vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
+      {
+        "proof": {
+          "type": "EcdsaSecp256k1Signature2019",
+          "proofPurpose": "assertionMethod",
+          "verificationMethod": `data:application/json;base64,${encoded3}`,
+          "created": "2024-06-14T10:56:59.948091Z",
+          "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..Q1mj3jMf5DWK83E55r6vNUPpsYYgclgwYoNFBSYBzA5x6fI_2cPHJsXECnQlG1XMj2ifldngpJXegTpwe3Fgwg"
+        },
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://w3id.org/vc/status-list/2021/v1"
+        ],
+        "type": [
+          "VerifiableCredential",
+          "StatusList2021Credential"
+        ],
+        "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
+        "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
+        "issuanceDate": 1717714047,
+        "credentialSubject": {
+          "type": "StatusList2021",
+          "statusPurpose": "Revocation",
+          "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
+        }
+      }, 200)
+    );
 
-        await expect(sut)
-            .to.eventually.rejectedWith(`Couldn't ungzip base64 encoded list, err: whatever`)
-    })
+    const sut = testCtx.run(new RunProtocol({
+      type: "revocation-check",
+      pid: "prism/jwt",
+      data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
+    }));
+
+    await expect(sut)
+      .to.eventually.rejectedWith("Err Invalid JWK kty: undefined, should be EC");
+
+  });
+
+  it("Should throw an error if a wrong key curve is used", async () => {
+    const encoded4 = base64.baseEncode(Buffer.from(JSON.stringify({ type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019, publicKeyJwk: { x: "423", y: "123", kty: KeyTypes.EC } })));
+    vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
+      {
+        "proof": {
+          "type": "EcdsaSecp256k1Signature2019",
+          "proofPurpose": "assertionMethod",
+          "verificationMethod": `data:application/json;base64,${encoded4}`,
+          "created": "2024-06-14T10:56:59.948091Z",
+          "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..Q1mj3jMf5DWK83E55r6vNUPpsYYgclgwYoNFBSYBzA5x6fI_2cPHJsXECnQlG1XMj2ifldngpJXegTpwe3Fgwg"
+        },
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://w3id.org/vc/status-list/2021/v1"
+        ],
+        "type": [
+          "VerifiableCredential",
+          "StatusList2021Credential"
+        ],
+        "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
+        "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
+        "issuanceDate": 1717714047,
+        "credentialSubject": {
+          "type": "StatusList2021",
+          "statusPurpose": "Revocation",
+          "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
+        }
+      }, 200)
+    );
+
+    const sut = testCtx.run(new RunProtocol({
+      type: "revocation-check",
+      pid: "prism/jwt",
+      data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
+    }));
+
+    await expect(sut)
+      .to.eventually.rejectedWith("Err Invalid JWK crv: undefined, should be secp256k1");
+  });
+
+  it("Should throw an eror if an invalid verificationKey is used", async () => {
+    const encoded5 = base64.baseEncode(Buffer.from(JSON.stringify({ type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019, publicKeyJwk: { x: 'TYBgml3TiQdR_YQD1hIuNO8bRynSJ-rlPqaUwrWkq-E=', y: 'V0gTYA3LalWwCxOdyjofhGbdaQDwq0AwBnShtRK_3Xg=', kty: KeyTypes.EC, crv: Curve.SECP256K1.toLocaleLowerCase() } })));
+    const pk = { ...Fixtures.Keys.secp256K1.publicKey } as any;
+
+    pk.canVerify = () => false;
+    vi.spyOn(apollo, "createPublicKey").mockReturnValue(pk);
+
+    vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
+      {
+        "proof": {
+          "type": "EcdsaSecp256k1Signature2019",
+          "proofPurpose": "assertionMethod",
+          "verificationMethod": `data:application/json;base64,${encoded5}`,
+          "created": "2024-06-14T10:56:59.948091Z",
+          "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..Q1mj3jMf5DWK83E55r6vNUPpsYYgclgwYoNFBSYBzA5x6fI_2cPHJsXECnQlG1XMj2ifldngpJXegTpwe3Fgwg"
+        },
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://w3id.org/vc/status-list/2021/v1"
+        ],
+        "type": [
+          "VerifiableCredential",
+          "StatusList2021Credential"
+        ],
+        "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
+        "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
+        "issuanceDate": 1717714047,
+        "credentialSubject": {
+          "type": "StatusList2021",
+          "statusPurpose": "Revocation",
+          "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
+        }
+      }, 200)
+    );
+
+    const sut = testCtx.run(new RunProtocol({
+      type: "revocation-check",
+      pid: "prism/jwt",
+      data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
+    }));
+
+    await expect(sut)
+      .to.eventually.rejectedWith("CredentialStatus proof invalid verifying key");
+  });
+
+  it("Should throw an error if the status jwt is invalid", async () => {
+    const encoded6 = base64.baseEncode(Buffer.from(JSON.stringify({ type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019, publicKeyJwk: { x: 'TYBgml3TiQdR_YQD1hIuNO8bRynSJ-rlPqaUwrWkq-E=', y: 'V0gTYA3LalWwCxOdyjofhGbdaQDwq0AwBnShtRK_3Xg=', kty: KeyTypes.EC, crv: Curve.SECP256K1.toLocaleLowerCase() } })));
+
+    vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
+      {
+        "proof": {
+          "type": "EcdsaSecp256k1Signature2019",
+          "proofPurpose": "assertionMethod",
+          "verificationMethod": `data:application/json;base64,${encoded6}`,
+          "created": "2024-06-14T10:56:59.948091Z",
+          "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ."
+        },
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://w3id.org/vc/status-list/2021/v1"
+        ],
+        "type": [
+          "VerifiableCredential",
+          "StatusList2021Credential"
+        ],
+        "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
+        "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
+        "issuanceDate": 1717714047,
+        "credentialSubject": {
+          "type": "StatusList2021",
+          "statusPurpose": "Revocation",
+          "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
+        }
+      }, 200)
+    );
+
+    const sut = testCtx.run(new RunProtocol({
+      type: "revocation-check",
+      pid: "prism/jwt",
+      data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
+    }));
+
+    await expect(sut)
+      .to.eventually.rejectedWith("Credential status jwt is invalid");
+  });
+
+  it("should throw an error if wrong signature is used", async () => {
+    const pk2 = { ...Fixtures.Keys.secp256K1.publicKey } as any;
+    (pk2 as any).verify = () => false;
+    (pk2 as any).canVerify = () => true;
+    const encoded8 = base64.baseEncode(
+      Buffer.from(
+        JSON.stringify({
+          type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019,
+          publicKeyJwk: {
+            x: 'TYBgml3TiQdR_YQD1hIuNO8bRynSJ-rlPqaUwrWkq-E=',
+            y: 'V0gTYA3LalWwCxOdyjofhGbdaQDwq0AwBnShtRK_3Xg=',
+            kty: KeyTypes.EC,
+            crv: Curve.SECP256K1.toLocaleLowerCase()
+          }
+        }
+        )
+      )
+    );
+
+    vi.spyOn(apollo, "createPublicKey").mockReturnValue(pk2);
+
+    vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
+      {
+        "proof": {
+          "type": "EcdsaSecp256k1Signature2019",
+          "proofPurpose": "assertionMethod",
+          "verificationMethod": `data:application/json;base64,${encoded8}`,
+          "created": "2024-06-14T10:56:59.948091Z",
+          "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..Q1mj3jMf5DWK83E55r6vNUPpsYYgclgwYoNFBSYBzA5x6fI_2cPHJsXECnQlG1XMj2ifldngpJXegTpwe3Fgwg"
+        },
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://w3id.org/vc/status-list/2021/v1"
+        ],
+        "type": [
+          "VerifiableCredential",
+          "StatusList2021Credential"
+        ],
+        "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
+        "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
+        "issuanceDate": 1717714047,
+        "credentialSubject": {
+          "type": "StatusList2021",
+          "statusPurpose": "Revocation",
+          "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
+        }
+      }, 200)
+    );
+
+    const sut = testCtx.run(new RunProtocol({
+      type: "revocation-check",
+      pid: "prism/jwt",
+      data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
+    }));
+
+    await expect(sut)
+      .to.eventually.rejectedWith("CredentialStatus invalid signature");
+  });
+
+  it("Should throw an error if we cannot decode the revocation registry correctly ", async () => {
+    const pakoPkg = await import('pako');
+    // (pakoPkg as any).ungzip = vi.fn().mockImplementation(() => { throw new Error('whatever'); });
+
+    // (await vi.importActual('pako')).ungzip;
+
+    // const pako = await import("pako");
+    const spy = vi.spyOn(pakoPkg, "ungzip").mockImplementation(() => { throw new Error('whatever'); });
+    // vi.mocked(pako.ungzip).mockImplementation(() => { throw new Error('whatever'); })
 
 
-    it("Should throw an error if the status proof type is invalid", async () => {
-        const encoded6 = base64.baseEncode(Buffer.from(JSON.stringify({ type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019, publicKeyJwk: { x: 'TYBgml3TiQdR_YQD1hIuNO8bRynSJ-rlPqaUwrWkq-E=', y: 'V0gTYA3LalWwCxOdyjofhGbdaQDwq0AwBnShtRK_3Xg=', kty: KeyTypes.EC, crv: Curve.SECP256K1.toLocaleLowerCase() } })))
-        vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
-            {
-                "proof": {
-                    "type": "EcdsaSecp256k1Signature2024",
-                    "proofPurpose": "assertionMethod",
-                    "verificationMethod": `data:application/json;base64,${encoded6}`,
-                    "created": "2024-06-14T10:56:59.948091Z",
-                    "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ."
-                },
-                "@context": [
-                    "https://www.w3.org/2018/credentials/v1",
-                    "https://w3id.org/vc/status-list/2021/v1"
-                ],
-                "type": [
-                    "VerifiableCredential",
-                    "StatusList2021Credential"
-                ],
-                "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
-                "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
-                "issuanceDate": 1717714047,
-                "credentialSubject": {
-                    "type": "StatusList2021",
-                    "statusPurpose": "Revocation",
-                    "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
-                }
-              }, 200)
-        );
+    vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
+      {
+        "proof": {
+          "type": "EcdsaSecp256k1Signature2019",
+          "proofPurpose": "assertionMethod",
+          "verificationMethod": "data:application/json;base64,eyJAY29udGV4dCI6WyJodHRwczovL3czaWQub3JnL3NlY3VyaXR5L3YxIl0sInR5cGUiOiJFY2RzYVNlY3AyNTZrMVZlcmlmaWNhdGlvbktleTIwMTkiLCJwdWJsaWNLZXlKd2siOnsiY3J2Ijoic2VjcDI1NmsxIiwia2V5X29wcyI6WyJ2ZXJpZnkiXSwia3R5IjoiRUMiLCJ4IjoiVFlCZ21sM1RpUWRSX1lRRDFoSXVOTzhiUnluU0otcmxQcWFVd3JXa3EtRT0iLCJ5IjoiVjBnVFlBM0xhbFd3Q3hPZHlqb2ZoR2JkYVFEd3EwQXdCblNodFJLXzNYZz0ifX0=",
+          "created": "2024-06-14T10:56:59.948091Z",
+          "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ..Q1mj3jMf5DWK83E55r6vNUPpsYYgclgwYoNFBSYBzA5x6fI_2cPHJsXECnQlG1XMj2ifldngpJXegTpwe3Fgwg"
+        },
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://w3id.org/vc/status-list/2021/v1"
+        ],
+        "type": [
+          "VerifiableCredential",
+          "StatusList2021Credential"
+        ],
+        "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
+        "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
+        "issuanceDate": 1717714047,
+        "credentialSubject": {
+          "type": "StatusList2021",
+          "statusPurpose": "Revocation",
+          "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
+        }
+      }, 200)
+    );
 
-        const sut = testCtx.run(new RunProtocol({
-          type: "revocation-check",
-          pid: "prism/jwt",
-          data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
-        }));
+    const sut = testCtx.run(new RunProtocol({
+      type: "revocation-check",
+      pid: "prism/jwt",
+      data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
+    }));
 
-        await expect(sut)
-            .to.eventually.rejectedWith("CredentialStatus proof type not supported")
-    })
+    await expect(sut)
+      .to.eventually.rejectedWith(`Couldn't ungzip base64 encoded list, err: whatever`);
+  });
+
+
+  it("Should throw an error if the status proof type is invalid", async () => {
+    const encoded6 = base64.baseEncode(Buffer.from(JSON.stringify({ type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019, publicKeyJwk: { x: 'TYBgml3TiQdR_YQD1hIuNO8bRynSJ-rlPqaUwrWkq-E=', y: 'V0gTYA3LalWwCxOdyjofhGbdaQDwq0AwBnShtRK_3Xg=', kty: KeyTypes.EC, crv: Curve.SECP256K1.toLocaleLowerCase() } })));
+    vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
+      {
+        "proof": {
+          "type": "EcdsaSecp256k1Signature2024",
+          "proofPurpose": "assertionMethod",
+          "verificationMethod": `data:application/json;base64,${encoded6}`,
+          "created": "2024-06-14T10:56:59.948091Z",
+          "jws": "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJFUzI1NksifQ."
+        },
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://w3id.org/vc/status-list/2021/v1"
+        ],
+        "type": [
+          "VerifiableCredential",
+          "StatusList2021Credential"
+        ],
+        "id": "http://localhost:8085/credential-status/575092c2-7eb0-40ae-8f41-3b499f45f3dc",
+        "issuer": "did:prism:462c4811bf61d7de25b3baf86c5d2f0609b4debe53792d297bf612269bf8593a",
+        "issuanceDate": 1717714047,
+        "credentialSubject": {
+          "type": "StatusList2021",
+          "statusPurpose": "Revocation",
+          "encodedList": "H4sIAAAAAAAA_-3BMQ0AAAACIGf_0MbwARoAAAAAAAAAAAAAAAAAAADgbbmHB0sAQAAA"
+        }
+      }, 200)
+    );
+
+    const sut = testCtx.run(new RunProtocol({
+      type: "revocation-check",
+      pid: "prism/jwt",
+      data: { credential: JWTCredential.fromJWS(revocableJWTCredential) }
+    }));
+
+    await expect(sut)
+      .to.eventually.rejectedWith("CredentialStatus proof type not supported");
+  });
 });

--- a/tests/pollux/SDJWT.test.ts
+++ b/tests/pollux/SDJWT.test.ts
@@ -15,7 +15,7 @@ describe("Domain - SDJWT", () => {
     apollo = new Apollo();
     castor = new Castor(apollo);
     plutoMock = { getDIDPrivateKeysByDID: vi.fn() } as any;
-    const ctx = Task.Context.make({
+    const ctx = new Task.Context({
       Apollo: apollo,
       Castor: castor,
       Pluto: plutoMock,


### PR DESCRIPTION
### Description: 
Move towards making Tasks available on the package, for fine-grained control.
Agent.runTask has also been made public to provide an easy way to run the Tasks.

Renamed DIDCommContext to AgentContext, to simplify the meaning, and the other agents will be removed soon

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
