### PR TITLE
fix: incorrect handling of verification method affecting did resolution

### DIFF
--- a/src/castor/Castor.ts
+++ b/src/castor/Castor.ts
@@ -26,6 +26,8 @@ import {
   VerificationMethods as DIDDocumentVerificationMethods,
   getUsageFromId,
   getUsageId,
+  isEd25519VerificationKey,
+  isSecp256k1VerificationKey,
   PrivateKey,
   Usage,
   VerificationMethod,
@@ -122,19 +124,19 @@ export default class Castor implements CastorInterface {
       }
     } else if (verificationMethod.publicKeyMultibase) {
       const raw = base58.base58btc.decode(verificationMethod.publicKeyMultibase)
-      if (verificationMethod.type === Curve.SECP256K1) {
+      if (verificationMethod.type === "EcdsaSecp256k1VerificationKey2019") {
         return new PrismDIDPublicKey(
           getUsageId(usage, index),
           usage,
           new Secp256k1PublicKey(raw)
         );
-      } else if (verificationMethod.type === Curve.ED25519) {
+      } else if (verificationMethod.type === "Ed25519VerificationKey2018" || verificationMethod.type === "Ed25519VerificationKey2020") {
         return new PrismDIDPublicKey(
           getUsageId(usage, index),
           usage,
           new Ed25519PublicKey(raw)
         );
-      } else if (verificationMethod.type === Curve.X25519) {
+      } else if (verificationMethod.type === "X25519KeyAgreementKey2019" || verificationMethod.type === "X25519KeyAgreementKey2020") {
         return new PrismDIDPublicKey(
           getUsageId(usage, index),
           usage,
@@ -430,7 +432,7 @@ export default class Castor implements CastorInterface {
 
     if (did.method == "prism") {
       const methods = verificationMethods.filter(
-        (method) => method.type == Curve.SECP256K1 || method.type === Curve.ED25519
+        (method) => isSecp256k1VerificationKey(method.type) || isEd25519VerificationKey(method.type)
       );
       if (methods.length <= 0) {
         throw new Error("No verification methods for Prism DID");
@@ -442,7 +444,7 @@ export default class Castor implements CastorInterface {
               "PrismDID VerificationMethod does not have multibase Key in it"
             );
           }
-          if (method.type === Curve.SECP256K1) {
+          if (isSecp256k1VerificationKey(method.type)) {
             const publicKey = Secp256k1PublicKey.secp256k1FromBytes(
               Buffer.from(base58.base58btc.decode(method.publicKeyMultibase))
             );
@@ -455,7 +457,7 @@ export default class Castor implements CastorInterface {
             }
 
           }
-          if (method.type === Curve.ED25519) {
+          if (isEd25519VerificationKey(method.type)) {
             const publicKey = new Ed25519PublicKey(
               Buffer.from(base58.base58btc.decode(method.publicKeyMultibase))
             );

--- a/src/castor/resolver/LongFormPrismDIDResolver.ts
+++ b/src/castor/resolver/LongFormPrismDIDResolver.ts
@@ -17,6 +17,8 @@ import {
   PublicKey,
   Curve,
   getUsage,
+  VerificationMethodType,
+  getCurveVerificationMethodType,
 } from "../../domain/models";
 
 import * as DIDParser from "../parser/DIDParser";
@@ -158,7 +160,7 @@ export class LongFormPrismDIDResolver implements DIDResolver {
           const method = new DIDDocumentVerificationMethod(
             didUrl.string(),
             did.toString(),
-            curve,
+            getCurveVerificationMethodType(curve),
             undefined,
             base58.base58btc.encode(publicKey.keyData.raw)
           );

--- a/src/castor/resolver/LongFormPrismDIDResolver.ts
+++ b/src/castor/resolver/LongFormPrismDIDResolver.ts
@@ -17,7 +17,6 @@ import {
   PublicKey,
   Curve,
   getUsage,
-  VerificationMethodType,
   getCurveVerificationMethodType,
 } from "../../domain/models";
 

--- a/src/castor/resolver/PeerDIDResolver.ts
+++ b/src/castor/resolver/PeerDIDResolver.ts
@@ -205,7 +205,7 @@ export class PeerDIDResolver implements DIDResolver {
     return {
       id: new DIDUrl(did, [], new Map(), keyId).string(),
       controller: did.toString(),
-      type: decodedEncnumbasis[1].keyType.value,
+      type: 'JsonWebKey2020',
       publicKeyJwk: jsonObject,
     };
   }

--- a/src/castor/types/index.ts
+++ b/src/castor/types/index.ts
@@ -8,10 +8,3 @@ export type PeerDIDKeys = {
   encryptionKeys: VerificationMaterialAgreement[];
 };
 
-export enum VerificationKeyType {
-  Ed25519VerificationKey2018 = "Ed25519VerificationKey2018",
-  Ed25519VerificationKey2020 = "Ed25519VerificationKey2020",
-  X25519KeyAgreementKey2019 = "X25519KeyAgreementKey2019",
-  X25519KeyAgreementKey2020 = "X25519KeyAgreementKey2020",
-  EcdsaSecp256k1VerificationKey2019 = "EcdsaSecp256k1VerificationKey2019",
-}

--- a/src/domain/models/DIDDocument.ts
+++ b/src/domain/models/DIDDocument.ts
@@ -10,11 +10,57 @@ export class ServiceEndpoint {
   ) {}
 }
 
+export function decodeVerificationMethodType(verificationMethod: string): verificationMethod is VerificationMethodType {
+  return verificationMethod === "EcdsaSecp256k1VerificationKey2019" ||
+    verificationMethod === "Ed25519VerificationKey2018" ||
+    verificationMethod === "Ed25519VerificationKey2020" ||
+    verificationMethod === "X25519KeyAgreementKey2019" ||
+    verificationMethod === "X25519KeyAgreementKey2020" ||
+    verificationMethod === "JsonWebKey2020"
+}
+
+export function getCurveVerificationMethodType(curve: string): VerificationMethodType {
+  if (curve === Curve.SECP256K1) {
+    return "EcdsaSecp256k1VerificationKey2019";
+  }
+  if (curve === Curve.ED25519) {
+    return "Ed25519VerificationKey2020";
+  }
+
+  if (curve === Curve.X25519) {
+    return "X25519KeyAgreementKey2020";
+  }
+
+  return "JsonWebKey2020"
+}
+
+export function isEd25519VerificationKey(verificationMethod: string): boolean {
+  return verificationMethod === "Ed25519VerificationKey2018" ||
+    verificationMethod === "Ed25519VerificationKey2020"
+}
+
+export function isSecp256k1VerificationKey(verificationMethod: string): boolean {
+  return verificationMethod === "EcdsaSecp256k1VerificationKey2019"
+}
+
+export function isX25519KeyAgreementKey(verificationMethod: string): boolean {
+  return verificationMethod === "X25519KeyAgreementKey2019" ||
+    verificationMethod === "X25519KeyAgreementKey2020"
+}
+
+export type VerificationMethodType =
+  "JsonWebKey2020" |
+  "Ed25519VerificationKey2018" |
+  "Ed25519VerificationKey2020" |
+  "X25519KeyAgreementKey2019" |
+  "X25519KeyAgreementKey2020" |
+  "EcdsaSecp256k1VerificationKey2019";
+
 export class VerificationMethod {
   constructor(
     public id: string,
     public controller: string,
-    public type: string,
+    public type: VerificationMethodType,
     public publicKeyJwk?: PublicKeyJWK,
     public publicKeyMultibase?: string
   ) {}

--- a/src/mercury/didcomm/DIDResolver.ts
+++ b/src/mercury/didcomm/DIDResolver.ts
@@ -40,7 +40,7 @@ export class DIDCommDIDResolver implements DIDResolver {
           verificationMethods.push({
             controller: method.controller,
             id: method.id,
-            type: "JsonWebKey2020",
+            type: "JsonWebKey2020" as Domain.VerificationMethodType,
             publicKeyJwk: {
               crv: method.publicKeyJwk?.crv,
               kid: publicKeyKid,

--- a/src/peer-did/types.ts
+++ b/src/peer-did/types.ts
@@ -1,3 +1,5 @@
+import { VerificationMethodType } from "../domain/models/DIDDocument";
+
 export enum VerificationMaterialFormatPeerDID {
   JWK = "jwk",
 }
@@ -6,8 +8,8 @@ export interface VerificationMethodTypePeerDID {
   value: string;
 }
 
-export class VerificationMethodType implements VerificationMethodTypePeerDID {
-  constructor(public value: string) {}
+export class BaseVerificationMethod implements VerificationMethodTypePeerDID {
+  constructor(public value: VerificationMethodType) { }
 }
 
 export enum Numalgo2Prefix {
@@ -22,26 +24,31 @@ export type OctetPublicKey = {
   x: string;
 };
 
-export class VerificationMethodTypeAgreement extends VerificationMethodType {
+export class VerificationMethodTypeAgreement extends BaseVerificationMethod {
   static JSON_WEB_KEY_2020 = new VerificationMethodTypeAgreement(
     "JsonWebKey2020"
   );
   static X25519_KEY_AGREEMENT_KEY_2019 = new VerificationMethodTypeAgreement(
     "X25519KeyAgreementKey2019"
+
   );
   static X25519_KEY_AGREEMENT_KEY_2020 = new VerificationMethodTypeAgreement(
     "X25519KeyAgreementKey2020"
   );
 }
 
-export class VerificationMethodTypeAuthentication extends VerificationMethodType {
+export class VerificationMethodTypeAuthentication extends BaseVerificationMethod {
   static JSON_WEB_KEY_2020 = new VerificationMethodTypeAuthentication(
     "JsonWebKey2020"
   );
   static ED25519_KEY_AGREEMENT_KEY_2018 =
-    new VerificationMethodTypeAuthentication("Ed25519VerificationKey2018");
+    new VerificationMethodTypeAuthentication(
+      "Ed25519VerificationKey2018"
+    );
   static ED25519_KEY_AGREEMENT_KEY_2020 =
-    new VerificationMethodTypeAuthentication("Ed25519VerificationKey2020");
+    new VerificationMethodTypeAuthentication(
+      "Ed25519VerificationKey2020"
+    );
 }
 
 export interface VerificationMethodTypePeerDIDWithAgreement

--- a/src/plugins/internal/dif/IsCredentialRevoked.ts
+++ b/src/plugins/internal/dif/IsCredentialRevoked.ts
@@ -9,7 +9,6 @@ import { JWTCredential } from "../../../pollux/models/JWTVerifiableCredential";
 import { Bitstring } from "../../../pollux/utils/Bitstring";
 import type { Context } from "./index";
 // ?? dont import from Castor, lift to domain?
-import { VerificationKeyType } from "../../../castor/types";
 import { Plugins } from '../../types';
 import { Payload } from '../../../domain/protocols/Payload';
 
@@ -134,12 +133,12 @@ export class IsCredentialRevoked extends Plugins.Task<Args> {
 
       if (proofType === JWTProofType.EcdsaSecp256k1Signature2019) {
         const { publicKeyJwk } = decodedVerificationMethod;
-        const verificationMethodType = decodedVerificationMethod.type;
+        const verificationMethodType = Domain.decodeVerificationMethodType(decodedVerificationMethod.type);
         if (!publicKeyJwk) {
           throw new Domain.PolluxError.InvalidCredentialStatus("No public jwk provided");
         }
-        if (verificationMethodType !== VerificationKeyType.EcdsaSecp256k1VerificationKey2019) {
-          throw new Domain.PolluxError.InvalidCredentialStatus(`Only ${VerificationKeyType.EcdsaSecp256k1VerificationKey2019} is supported`);
+        if (!verificationMethodType || decodedVerificationMethod.type !== "EcdsaSecp256k1VerificationKey2019") {
+          throw new Domain.PolluxError.InvalidCredentialStatus(`Only EcdsaSecp256k1VerificationKey2019 is supported`);
         }
         const curve = decodedVerificationMethod.publicKeyJwk.crv;
         const kty = decodedVerificationMethod.publicKeyJwk.kty;

--- a/src/pollux/utils/jwt/JWT.ts
+++ b/src/pollux/utils/jwt/JWT.ts
@@ -58,9 +58,9 @@ export class JWT extends Task.Runner {
 
       const decoded = await this.decode(jws);
 
-      for (const vm of verificationMethods) {
+      for (const verificationMethod of verificationMethods) {
         try {
-          const pk = await this.runTask(new PKInstance({ verificationMethod: vm }));
+          const pk = await this.runTask(new PKInstance({ verificationMethod }));
 
           if (isNil(pk) || !pk.canVerify()) {
             throw new Error("Invalid key verification method type found");

--- a/src/pollux/utils/jwt/PKInstance.ts
+++ b/src/pollux/utils/jwt/PKInstance.ts
@@ -3,14 +3,12 @@ import { base58btc } from 'multiformats/bases/base58';
 import * as Domain from "../../../domain";
 import { isObject, notEmptyString, Task } from "../../../utils";
 // TODO importing from Castor
-import { VerificationKeyType } from "../../../castor/types";
 import { FromJWK } from "./FromJWK";
 import { AgentContext } from "../../../edge-agent/didcomm/Context";
+
 export interface Args {
-  verificationMethod: DIDResolver.VerificationMethod;
+  verificationMethod: Domain.VerificationMethod;
 }
-
-
 export class PKInstance extends Task<Domain.PublicKey | undefined, Args> {
   async run(ctx: AgentContext) {
     const verificationMethod = this.args.verificationMethod;
@@ -18,15 +16,26 @@ export class PKInstance extends Task<Domain.PublicKey | undefined, Args> {
 
     if (notEmptyString(verificationMethod.publicKeyMultibase)) {
       const decoded = base58btc.decode(verificationMethod.publicKeyMultibase);
-      if (verificationMethod.type === VerificationKeyType.EcdsaSecp256k1VerificationKey2019) {
+      if (verificationMethod.type === "EcdsaSecp256k1VerificationKey2019") {
         pk = ctx.Apollo.createPublicKey({
           [Domain.KeyProperties.curve]: Domain.Curve.SECP256K1,
           [Domain.KeyProperties.rawKey]: decoded
         });
-      } else if (verificationMethod.type === VerificationKeyType.Ed25519VerificationKey2018 ||
-        verificationMethod.type === VerificationKeyType.Ed25519VerificationKey2020) {
+      } else if (verificationMethod.type === "Ed25519VerificationKey2018" ||
+        verificationMethod.type === "Ed25519VerificationKey2020") {
         pk = ctx.Apollo.createPublicKey({
           [Domain.KeyProperties.curve]: Domain.Curve.ED25519,
+          [Domain.KeyProperties.rawKey]: decoded
+        });
+      } else if (verificationMethod.type === "X25519KeyAgreementKey2019" ||
+        verificationMethod.type === "X25519KeyAgreementKey2020") {
+        pk = ctx.Apollo.createPublicKey({
+          [Domain.KeyProperties.curve]: Domain.Curve.X25519,
+          [Domain.KeyProperties.rawKey]: decoded
+        });
+      } else if (verificationMethod.type === "JsonWebKey2020") {
+        pk = ctx.Apollo.createPublicKey({
+          [Domain.KeyProperties.curve]: Domain.Curve.SECP256K1,
           [Domain.KeyProperties.rawKey]: decoded
         });
       }

--- a/src/pollux/utils/jwt/PKInstance.ts
+++ b/src/pollux/utils/jwt/PKInstance.ts
@@ -1,4 +1,3 @@
-import type * as DIDResolver from "did-resolver";
 import { base58btc } from 'multiformats/bases/base58';
 import * as Domain from "../../../domain";
 import { isObject, notEmptyString, Task } from "../../../utils";

--- a/src/pollux/utils/jwt/ResolveDID.ts
+++ b/src/pollux/utils/jwt/ResolveDID.ts
@@ -24,6 +24,28 @@ export class ResolveDID extends Task<DIDResolver.DIDResolutionResult, Args> {
       (prop): prop is Domain.Services => prop instanceof Domain.Services
     );
 
+
+    const verificationMethod = asArray(verificationMethods?.values).map((vm) => {
+      if (vm.publicKeyMultibase) {
+        return {
+          id: vm.id,
+          type: vm.type,
+          controller: vm.controller,
+          publicKeyMultibase: vm.publicKeyMultibase,
+        };
+      }
+
+      if (vm.publicKeyJwk) {
+        return {
+          id: vm.id,
+          type: "JsonWebKey2020" as Domain.VerificationMethodType,
+          controller: vm.controller,
+          publicKeyJwk: vm.publicKeyJwk,
+        };
+      }
+
+      throw new Error("Invalid KeyType");
+    })
     return {
       didResolutionMetadata: { contentType: "application/did+ld+json" },
       didDocumentMetadata: {},
@@ -31,34 +53,9 @@ export class ResolveDID extends Task<DIDResolver.DIDResolutionResult, Args> {
         id: resolved.id.toString(),
         alsoKnownAs: alsoKnownAs?.values,
         controller: asArray(controller?.values).map((v) => v.toString()),
-        verificationMethod: asArray(verificationMethods?.values).map((vm) => {
-          if (vm.publicKeyMultibase) {
-            return {
-              id: vm.id,
-              type: vm.type === Domain.Curve.SECP256K1
-                ? "EcdsaSecp256k1VerificationKey2019"
-                : vm.type === Domain.Curve.ED25519
-                  ? 'Ed25519VerificationKey2020'
-                  : 'unknown',
-              controller: vm.controller,
-              publicKeyMultibase: vm.publicKeyMultibase,
-            };
-          }
-
-          if (vm.publicKeyJwk) {
-            return {
-              id: vm.id,
-              type: "JsonWebKey2020",
-              controller: vm.controller,
-              publicKeyJwk: vm.publicKeyJwk,
-            };
-          }
-
-          throw new Error("Invalid KeyType");
-        }),
+        verificationMethod,
         service: asArray(service?.values).reduce<DIDResolver.Service[]>((acc, service) => {
           const type = service.type.at(0);
-
           return isEmpty(type) ? acc : acc.concat({
             type: type,
             id: service.id,

--- a/tests/castor/PrismDID.test.ts
+++ b/tests/castor/PrismDID.test.ts
@@ -2,7 +2,7 @@ import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { base58btc } from "multiformats/bases/base58";
 import { describe, assert, it, expect, test, beforeEach, afterEach } from 'vitest';
-import { Authentication, Curve, DIDDocument, getProtosUsage, getUsageId, JWT_ALG, KeyTypes, PublicKey, Services, Usage, VerificationMethod, VerificationMethods } from "../../src/domain";
+import { Authentication, Curve, DIDDocument, getCurveVerificationMethodType, getProtosUsage, getUsageId, JWT_ALG, KeyTypes, PublicKey, Services, Usage, VerificationMethod, VerificationMethods } from "../../src/domain";
 import Apollo from "../../src/apollo/Apollo";
 import Castor from "../../src/castor/Castor";
 import * as ECConfig from "../../src/domain/models/ECConfig";
@@ -143,7 +143,7 @@ describe("PrismDID", () => {
         expect(cp0vm0?.id).to.eq(`${didStr}#master-0`);
         expect(cp0vm0?.publicKeyJwk).to.be.undefined;
         expect(cp0vm0?.publicKeyMultibase).to.eq("zSXxpYB6edvxvWxRTo3kMUoTTQVHpbNnXo2Z1AjLA78iqLdK2kVo5xw9rGg8uoEgmhxYahNur3RvV7HnaktWBqkXt");
-        expect(cp0vm0?.type).to.eq(Curve.SECP256K1);
+        expect(cp0vm0?.type).to.eq("EcdsaSecp256k1VerificationKey2019");
 
         const cp1 = sut.coreProperties.at(1) as Authentication;
         expect(cp1).to.be.instanceOf(Authentication);
@@ -154,7 +154,7 @@ describe("PrismDID", () => {
         expect(cp1vm0?.id).to.eq(`${didStr}#authentication-0`);
         expect(cp1vm0?.publicKeyJwk).to.be.undefined;
         expect(cp1vm0?.publicKeyMultibase).to.eq("zSXxpYB6edvxvWxRTo3kMUoTTQVHpbNnXo2Z1AjLA78iqLdK2kVo5xw9rGg8uoEgmhxYahNur3RvV7HnaktWBqkXt");
-        expect(cp1vm0?.type).to.eq(Curve.SECP256K1);
+        expect(cp1vm0?.type).to.eq("EcdsaSecp256k1VerificationKey2019");
 
         const cp2 = sut.coreProperties.at(2) as Services;
         expect(cp2).to.be.instanceOf(Services);
@@ -171,7 +171,7 @@ describe("PrismDID", () => {
         expect(cp3v0?.id).to.eq(`${didStr}#master-0`);
         expect(cp3v0?.publicKeyJwk).to.be.undefined;
         expect(cp3v0?.publicKeyMultibase).to.eq("zSXxpYB6edvxvWxRTo3kMUoTTQVHpbNnXo2Z1AjLA78iqLdK2kVo5xw9rGg8uoEgmhxYahNur3RvV7HnaktWBqkXt");
-        expect(cp3v0?.type).to.eq(Curve.SECP256K1);
+        expect(cp3v0?.type).to.eq("EcdsaSecp256k1VerificationKey2019");
 
         const cp3v1 = cp3.values.at(1);
         expect(cp3v1).to.be.instanceOf(VerificationMethod);
@@ -179,7 +179,7 @@ describe("PrismDID", () => {
         expect(cp3v1?.id).to.eq(`${didStr}#authentication-0`);
         expect(cp3v1?.publicKeyJwk).to.be.undefined;
         expect(cp3v1?.publicKeyMultibase).to.eq("zSXxpYB6edvxvWxRTo3kMUoTTQVHpbNnXo2Z1AjLA78iqLdK2kVo5xw9rGg8uoEgmhxYahNur3RvV7HnaktWBqkXt");
-        expect(cp3v1?.type).to.eq(Curve.SECP256K1);
+        expect(cp3v1?.type).to.eq("EcdsaSecp256k1VerificationKey2019");
       });
 
       const masterKeyId = getUsageId(Usage.MASTER_KEY);
@@ -191,7 +191,7 @@ describe("PrismDID", () => {
         expect(sut?.id).to.eq(`${didStr}#${keyId}`);
         expect(sut?.publicKeyJwk).to.be.undefined;
         expect(sut?.publicKeyMultibase).to.eq(keyMultibase);
-        expect(sut?.type).to.eq(curve);
+        expect(sut?.type).to.eq(getCurveVerificationMethodType(curve));
       };
 
       test("master key", async () => {

--- a/tests/plugins/dif/IsCredentialRevoked.test.ts
+++ b/tests/plugins/dif/IsCredentialRevoked.test.ts
@@ -257,7 +257,7 @@ describe("Plugins - DIF", () => {
     });
 
     it("Should throw an error if a wrong key type is used", async () => {
-      const encoded3 = base64.baseEncode(Buffer.from(JSON.stringify({ type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019, publicKeyJwk: { x: "423", y: "123" } })));
+      const encoded3 = base64.baseEncode(Buffer.from(JSON.stringify({ type: "EcdsaSecp256k1VerificationKey2019", publicKeyJwk: { x: "423", y: "123" } })));
       vi.spyOn(api, "request").mockResolvedValue(new ApiResponse({
         "proof": {
           "type": "EcdsaSecp256k1Signature2019",
@@ -292,7 +292,7 @@ describe("Plugins - DIF", () => {
     });
 
     it("Should throw an error if a wrong key curve is used", async () => {
-      const encoded4 = base64.baseEncode(Buffer.from(JSON.stringify({ type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019, publicKeyJwk: { x: "423", y: "123", kty: KeyTypes.EC } })));
+      const encoded4 = base64.baseEncode(Buffer.from(JSON.stringify({ type: "EcdsaSecp256k1VerificationKey2019", publicKeyJwk: { x: "423", y: "123", kty: KeyTypes.EC } })));
       vi.spyOn(api, "request").mockResolvedValue(new ApiResponse({
         "proof": {
           "type": "EcdsaSecp256k1Signature2019",
@@ -326,7 +326,7 @@ describe("Plugins - DIF", () => {
     });
 
     it("Should throw an eror if an invalid verificationKey is used", async () => {
-      const encoded5 = base64.baseEncode(Buffer.from(JSON.stringify({ type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019, publicKeyJwk: { x: 'TYBgml3TiQdR_YQD1hIuNO8bRynSJ-rlPqaUwrWkq-E=', y: 'V0gTYA3LalWwCxOdyjofhGbdaQDwq0AwBnShtRK_3Xg=', kty: KeyTypes.EC, crv: Curve.SECP256K1.toLocaleLowerCase() } })));
+      const encoded5 = base64.baseEncode(Buffer.from(JSON.stringify({ type: "EcdsaSecp256k1VerificationKey2019", publicKeyJwk: { x: 'TYBgml3TiQdR_YQD1hIuNO8bRynSJ-rlPqaUwrWkq-E=', y: 'V0gTYA3LalWwCxOdyjofhGbdaQDwq0AwBnShtRK_3Xg=', kty: KeyTypes.EC, crv: Curve.SECP256K1.toLocaleLowerCase() } })));
 
       // return privateKey so .canVerify() returns false
       vi.spyOn(apollo, "createPublicKey").mockReturnValue(Fixtures.Keys.ed25519.privateKey);
@@ -364,7 +364,7 @@ describe("Plugins - DIF", () => {
     });
 
     it("Should throw an error if the status jwt is invalid", async () => {
-      const encoded6 = base64.baseEncode(Buffer.from(JSON.stringify({ type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019, publicKeyJwk: { x: 'TYBgml3TiQdR_YQD1hIuNO8bRynSJ-rlPqaUwrWkq-E=', y: 'V0gTYA3LalWwCxOdyjofhGbdaQDwq0AwBnShtRK_3Xg=', kty: KeyTypes.EC, crv: Curve.SECP256K1.toLocaleLowerCase() } })));
+      const encoded6 = base64.baseEncode(Buffer.from(JSON.stringify({ type: "EcdsaSecp256k1VerificationKey2019", publicKeyJwk: { x: 'TYBgml3TiQdR_YQD1hIuNO8bRynSJ-rlPqaUwrWkq-E=', y: 'V0gTYA3LalWwCxOdyjofhGbdaQDwq0AwBnShtRK_3Xg=', kty: KeyTypes.EC, crv: Curve.SECP256K1.toLocaleLowerCase() } })));
 
       vi.spyOn(api, "request").mockResolvedValue(new ApiResponse({
         "proof": {
@@ -402,7 +402,7 @@ describe("Plugins - DIF", () => {
       const encoded8 = base64.baseEncode(
         Buffer.from(
           JSON.stringify({
-            type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019,
+            type: "EcdsaSecp256k1VerificationKey2019",
             publicKeyJwk: {
               x: 'TYBgml3TiQdR_YQD1hIuNO8bRynSJ-rlPqaUwrWkq-E=',
               y: 'V0gTYA3LalWwCxOdyjofhGbdaQDwq0AwBnShtRK_3Xg=',
@@ -492,7 +492,7 @@ describe("Plugins - DIF", () => {
     //*/
     it("Should throw an error if the status proof type is invalid", async () => {
       const encoded6 = base64.baseEncode(Buffer.from(JSON.stringify({
-        type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019,
+        type: "EcdsaSecp256k1VerificationKey2019",
         publicKeyJwk: { x: 'TYBgml3TiQdR_YQD1hIuNO8bRynSJ-rlPqaUwrWkq-E=', y: 'V0gTYA3LalWwCxOdyjofhGbdaQDwq0AwBnShtRK_3Xg=', kty: KeyTypes.EC, crv: Curve.SECP256K1.toLocaleLowerCase() }
       })));
       vi.spyOn(api, "request").mockResolvedValue(new ApiResponse({

--- a/tests/pollux/Pollux.revocation.test.ts
+++ b/tests/pollux/Pollux.revocation.test.ts
@@ -332,7 +332,7 @@ describe("Pollux", () => {
   });
 
   it("Should throw an error if a wrong key type is used", async () => {
-    const encoded3 = base64.baseEncode(Buffer.from(JSON.stringify({ type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019, publicKeyJwk: { x: "423", y: "123" } })));
+    const encoded3 = base64.baseEncode(Buffer.from(JSON.stringify({ type: "EcdsaSecp256k1VerificationKey2019", publicKeyJwk: { x: "423", y: "123" } })));
     vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
       {
         "proof": {
@@ -373,7 +373,7 @@ describe("Pollux", () => {
   });
 
   it("Should throw an error if a wrong key curve is used", async () => {
-    const encoded4 = base64.baseEncode(Buffer.from(JSON.stringify({ type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019, publicKeyJwk: { x: "423", y: "123", kty: KeyTypes.EC } })));
+    const encoded4 = base64.baseEncode(Buffer.from(JSON.stringify({ type: "EcdsaSecp256k1VerificationKey2019", publicKeyJwk: { x: "423", y: "123", kty: KeyTypes.EC } })));
     vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
       {
         "proof": {
@@ -413,7 +413,7 @@ describe("Pollux", () => {
   });
 
   it("Should throw an eror if an invalid verificationKey is used", async () => {
-    const encoded5 = base64.baseEncode(Buffer.from(JSON.stringify({ type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019, publicKeyJwk: { x: 'TYBgml3TiQdR_YQD1hIuNO8bRynSJ-rlPqaUwrWkq-E=', y: 'V0gTYA3LalWwCxOdyjofhGbdaQDwq0AwBnShtRK_3Xg=', kty: KeyTypes.EC, crv: Curve.SECP256K1.toLocaleLowerCase() } })));
+    const encoded5 = base64.baseEncode(Buffer.from(JSON.stringify({ type: "EcdsaSecp256k1VerificationKey2019", publicKeyJwk: { x: 'TYBgml3TiQdR_YQD1hIuNO8bRynSJ-rlPqaUwrWkq-E=', y: 'V0gTYA3LalWwCxOdyjofhGbdaQDwq0AwBnShtRK_3Xg=', kty: KeyTypes.EC, crv: Curve.SECP256K1.toLocaleLowerCase() } })));
     const pk = { ...Fixtures.Keys.secp256K1.publicKey } as any;
 
     pk.canVerify = () => false;
@@ -458,7 +458,7 @@ describe("Pollux", () => {
   });
 
   it("Should throw an error if the status jwt is invalid", async () => {
-    const encoded6 = base64.baseEncode(Buffer.from(JSON.stringify({ type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019, publicKeyJwk: { x: 'TYBgml3TiQdR_YQD1hIuNO8bRynSJ-rlPqaUwrWkq-E=', y: 'V0gTYA3LalWwCxOdyjofhGbdaQDwq0AwBnShtRK_3Xg=', kty: KeyTypes.EC, crv: Curve.SECP256K1.toLocaleLowerCase() } })));
+    const encoded6 = base64.baseEncode(Buffer.from(JSON.stringify({ type: "EcdsaSecp256k1VerificationKey2019", publicKeyJwk: { x: 'TYBgml3TiQdR_YQD1hIuNO8bRynSJ-rlPqaUwrWkq-E=', y: 'V0gTYA3LalWwCxOdyjofhGbdaQDwq0AwBnShtRK_3Xg=', kty: KeyTypes.EC, crv: Curve.SECP256K1.toLocaleLowerCase() } })));
 
     vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
       {
@@ -505,7 +505,7 @@ describe("Pollux", () => {
     const encoded8 = base64.baseEncode(
       Buffer.from(
         JSON.stringify({
-          type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019,
+          type: "EcdsaSecp256k1VerificationKey2019",
           publicKeyJwk: {
             x: 'TYBgml3TiQdR_YQD1hIuNO8bRynSJ-rlPqaUwrWkq-E=',
             y: 'V0gTYA3LalWwCxOdyjofhGbdaQDwq0AwBnShtRK_3Xg=',
@@ -608,7 +608,7 @@ describe("Pollux", () => {
 
 
   it("Should throw an error if the status proof type is invalid", async () => {
-    const encoded6 = base64.baseEncode(Buffer.from(JSON.stringify({ type: VerificationKeyType.EcdsaSecp256k1VerificationKey2019, publicKeyJwk: { x: 'TYBgml3TiQdR_YQD1hIuNO8bRynSJ-rlPqaUwrWkq-E=', y: 'V0gTYA3LalWwCxOdyjofhGbdaQDwq0AwBnShtRK_3Xg=', kty: KeyTypes.EC, crv: Curve.SECP256K1.toLocaleLowerCase() } })));
+    const encoded6 = base64.baseEncode(Buffer.from(JSON.stringify({ type: "EcdsaSecp256k1VerificationKey2019", publicKeyJwk: { x: 'TYBgml3TiQdR_YQD1hIuNO8bRynSJ-rlPqaUwrWkq-E=', y: 'V0gTYA3LalWwCxOdyjofhGbdaQDwq0AwBnShtRK_3Xg=', kty: KeyTypes.EC, crv: Curve.SECP256K1.toLocaleLowerCase() } })));
     vi.spyOn(api, "request").mockResolvedValue(new ApiResponse(
       {
         "proof": {


### PR DESCRIPTION
### Description: 
We are wrongly resolving the DIDs, which may not be directly impacting our users but our DIDDocuments are wrong in some cases.

Using Prism DID Long form, resolves verificationMethods correctly but their type is set to the curve value which is wrong and should be set to the VerificationMethod type.

See more [Here](https://github.com/hyperledger-identus/sdk-ts/issues/408)

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
