### PR TITLE
fix: export DIDCommConnection class on the SDK back to have the ability to establish connections with dids and oob codes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export { HandshakeRequest } from './edge-agent/protocols/connection/HandshakeReq
 export { OutOfBandInvitation } from './edge-agent/protocols/invitation/v2/OutOfBandInvitation';
 export * from "./edge-agent/protocols/proofPresentation";
 export * from "./edge-agent/connections/ConnectionsManager";
+export * from "./edge-agent/connections/didcomm/DIDCommConnection";
 export * from "./mercury/didcomm/Wrapper";
 export { FetchApi as ApiImpl } from "./edge-agent/helpers/FetchApi";
 export { ListenerKey } from "./edge-agent/types";


### PR DESCRIPTION

### Description: 
Exposing the DIDcommConnection class to restore the missing functionality

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
