### PR TITLE
fix: clean error instances if we find a valid path + add test rotating paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "elliptic": "^6.5.4",
         "jsdom": "^24.1.0",
         "rxjs": "^7.8.1",
-        "webdriverio": "^7.16.4"
+        "webdriverio": "^9.12.2"
       }
     },
     "externals/generated/anoncreds-wasm": {
@@ -127,11 +127,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.7",
+      "version": "7.26.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -395,7 +396,7 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.8",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -403,7 +404,7 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
+      "version": "7.25.9",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -432,37 +433,23 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.25.0",
+      "version": "7.27.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.24.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.4",
+      "version": "7.27.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.4"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1813,7 +1800,7 @@
       "license": "MIT"
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.4",
+      "version": "7.27.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1824,13 +1811,13 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.0",
+      "version": "7.27.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1854,13 +1841,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.4",
+      "version": "7.27.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2062,6 +2048,95 @@
         "stream-browserify": "3.0.0"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "dev": true,
@@ -2247,11 +2322,11 @@
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "10.1.1",
+      "version": "10.1.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^13.0.0",
+        "@octokit/types": "^13.6.2",
         "universal-user-agent": "^7.0.2"
       },
       "engines": {
@@ -2272,16 +2347,16 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "22.2.0",
+      "version": "24.2.0",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "11.3.3",
+      "version": "11.6.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^13.5.0"
+        "@octokit/types": "^13.10.0"
       },
       "engines": {
         "node": ">= 18"
@@ -2322,13 +2397,14 @@
       }
     },
     "node_modules/@octokit/request": {
-      "version": "9.1.3",
+      "version": "9.2.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/endpoint": "^10.0.0",
-        "@octokit/request-error": "^6.0.1",
-        "@octokit/types": "^13.1.0",
+        "@octokit/endpoint": "^10.1.3",
+        "@octokit/request-error": "^6.1.7",
+        "@octokit/types": "^13.6.2",
+        "fast-content-type-parse": "^2.0.0",
         "universal-user-agent": "^7.0.2"
       },
       "engines": {
@@ -2336,22 +2412,31 @@
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "6.1.4",
+      "version": "6.1.7",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^13.0.0"
+        "@octokit/types": "^13.6.2"
       },
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@octokit/types": {
-      "version": "13.5.0",
+      "version": "13.10.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/openapi-types": "^22.2.0"
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@playwright/test": {
@@ -2475,6 +2560,76 @@
       "version": "1.0.0-next.25",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@promptbook/utils": {
+      "version": "0.69.5",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://buymeacoffee.com/hejny"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/webgptorg/promptbook/blob/main/README.md#%EF%B8%8F-contributing"
+        }
+      ],
+      "license": "CC-BY-4.0",
+      "peer": true,
+      "dependencies": {
+        "spacetrim": "0.11.59"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.9.0",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.1",
+        "tar-fs": "^3.0.8",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/debug": {
+      "version": "4.4.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/ms": {
+      "version": "2.1.3",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@puppeteer/browsers/node_modules/semver": {
+      "version": "7.7.1",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.24.0",
@@ -2629,9 +2784,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.9.tgz",
-      "integrity": "sha512-FwBHNSOjUTQLP4MG7y6rR6qbGw4MFeQnIBrMe161QGaQoBQLqSUEKlHIiVgF3g/mb3lxlxzJOpIBhaP+C+KP2A==",
+      "version": "4.38.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.38.0.tgz",
+      "integrity": "sha512-vPvNgFlZRAgO7rwncMeE0+8c4Hmc+qixnp00/Uv3ht2x7KYrJ6ERVd3/R0nUtlE6/hu7/HiiNHJ/rP6knRFt1w==",
       "cpu": [
         "x64"
       ],
@@ -3309,17 +3464,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@semantic-release/npm/node_modules/type-fest": {
-      "version": "4.25.0",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@semantic-release/release-notes-generator": {
       "version": "10.0.3",
       "dev": true,
@@ -3349,6 +3493,7 @@
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3489,19 +3634,8 @@
         "@stablelib/wipe": "^1.0.1"
       }
     },
-    "node_modules/@szmarczak/http-timer": {
-      "version": "4.0.6",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "defer-to-connect": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
       "license": "MIT",
       "peer": true
     },
@@ -3519,17 +3653,6 @@
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/cacheable-request": {
-      "version": "6.0.3",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/http-cache-semantics": "*",
-        "@types/keyv": "^3.1.4",
-        "@types/node": "*",
-        "@types/responselike": "^1.0.0"
       }
     },
     "node_modules/@types/chai": {
@@ -3610,11 +3733,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/http-cache-semantics": {
-      "version": "4.0.4",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "dev": true,
@@ -3630,14 +3748,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/keyv": {
-      "version": "3.1.4",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/lokijs": {
       "version": "1.5.10",
       "dev": true,
@@ -3647,11 +3757,6 @@
       "version": "1.3.5",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/minimatch": {
-      "version": "5.1.2",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/minimist": {
       "version": "1.2.5",
@@ -3689,14 +3794,6 @@
       "version": "1.20.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/responselike": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/semver": {
       "version": "7.5.8",
@@ -3749,13 +3846,7 @@
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.5",
-      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/ua-parser-js": {
-      "version": "0.7.39",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
@@ -3772,13 +3863,12 @@
       }
     },
     "node_modules/@types/which": {
-      "version": "1.3.2",
+      "version": "2.0.2",
       "license": "MIT",
       "peer": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -4012,11 +4102,11 @@
       "license": "ISC"
     },
     "node_modules/@vitest/browser": {
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "1.6.0",
+        "@vitest/utils": "1.6.1",
         "magic-string": "^0.30.5",
         "sirv": "^2.0.4"
       },
@@ -4025,7 +4115,7 @@
       },
       "peerDependencies": {
         "playwright": "*",
-        "vitest": "1.6.0",
+        "vitest": "1.6.1",
         "webdriverio": "*"
       },
       "peerDependenciesMeta": {
@@ -4041,7 +4131,7 @@
       }
     },
     "node_modules/@vitest/coverage-istanbul": {
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4059,7 +4149,7 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "1.6.0"
+        "vitest": "1.6.1"
       }
     },
     "node_modules/@vitest/coverage-istanbul/node_modules/istanbul-lib-source-maps": {
@@ -4076,12 +4166,12 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "1.6.0",
-        "@vitest/utils": "1.6.0",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
         "chai": "^4.3.10"
       },
       "funding": {
@@ -4089,11 +4179,11 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "1.6.0",
+        "@vitest/utils": "1.6.1",
         "p-limit": "^5.0.0",
         "pathe": "^1.1.1"
       },
@@ -4116,7 +4206,7 @@
       }
     },
     "node_modules/@vitest/runner/node_modules/yocto-queue": {
-      "version": "1.1.1",
+      "version": "1.2.1",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4127,7 +4217,7 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4140,7 +4230,7 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4151,7 +4241,7 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4164,172 +4254,180 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/utils/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "node_modules/@wdio/config": {
-      "version": "7.33.0",
+      "version": "9.12.2",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@types/glob": "^8.1.0",
-        "@wdio/logger": "7.26.0",
-        "@wdio/types": "7.33.0",
-        "@wdio/utils": "7.33.0",
-        "deepmerge": "^4.0.0",
-        "glob": "^8.0.3"
+        "@wdio/logger": "9.4.4",
+        "@wdio/types": "9.12.2",
+        "@wdio/utils": "9.12.2",
+        "deepmerge-ts": "^7.0.3",
+        "glob": "^10.2.2",
+        "import-meta-resolve": "^4.0.0"
       },
       "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@wdio/config/node_modules/@types/glob": {
-      "version": "8.1.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/minimatch": "^5.1.2",
-        "@types/node": "*"
+        "node": ">=18.20.0"
       }
     },
     "node_modules/@wdio/logger": {
-      "version": "7.26.0",
+      "version": "9.4.4",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "chalk": "^4.0.0",
+        "chalk": "^5.1.2",
         "loglevel": "^1.6.0",
         "loglevel-plugin-prefix": "^0.8.4",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.20.0"
       }
     },
-    "node_modules/@wdio/logger/node_modules/ansi-styles": {
-      "version": "4.3.0",
+    "node_modules/@wdio/logger/node_modules/ansi-regex": {
+      "version": "6.1.0",
       "license": "MIT",
       "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/@wdio/logger/node_modules/chalk": {
-      "version": "4.1.2",
+      "version": "5.4.1",
       "license": "MIT",
       "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@wdio/logger/node_modules/color-convert": {
-      "version": "2.0.1",
+    "node_modules/@wdio/logger/node_modules/strip-ansi": {
+      "version": "7.1.0",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "color-name": "~1.1.4"
+        "ansi-regex": "^6.0.1"
       },
       "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@wdio/logger/node_modules/color-name": {
-      "version": "1.1.4",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@wdio/logger/node_modules/has-flag": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@wdio/logger/node_modules/supports-color": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
+        "node": ">=12"
       },
-      "engines": {
-        "node": ">=8"
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/@wdio/protocols": {
-      "version": "7.27.0",
+      "version": "9.12.2",
       "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=12.0.0"
-      }
+      "peer": true
     },
     "node_modules/@wdio/repl": {
-      "version": "7.33.0",
+      "version": "9.4.4",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@wdio/utils": "7.33.0"
+        "@types/node": "^20.1.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.20.0"
       }
+    },
+    "node_modules/@wdio/repl/node_modules/@types/node": {
+      "version": "20.17.29",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@wdio/repl/node_modules/undici-types": {
+      "version": "6.19.8",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@wdio/types": {
-      "version": "7.33.0",
+      "version": "9.12.2",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@types/node": "^18.0.0",
-        "got": "^11.8.1"
+        "@types/node": "^20.1.0"
       },
       "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "typescript": "^4.6.2"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "node": ">=18.20.0"
       }
     },
-    "node_modules/@wdio/utils": {
-      "version": "7.33.0",
+    "node_modules/@wdio/types/node_modules/@types/node": {
+      "version": "20.17.29",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@wdio/logger": "7.26.0",
-        "@wdio/types": "7.33.0",
-        "p-iteration": "^1.1.8"
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@wdio/types/node_modules/undici-types": {
+      "version": "6.19.8",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@wdio/utils": {
+      "version": "9.12.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@puppeteer/browsers": "^2.2.0",
+        "@wdio/logger": "9.4.4",
+        "@wdio/types": "9.12.2",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^7.0.3",
+        "edgedriver": "^6.1.1",
+        "geckodriver": "^5.0.0",
+        "get-port": "^7.0.0",
+        "import-meta-resolve": "^4.0.0",
+        "locate-app": "^2.2.24",
+        "safaridriver": "^1.0.0",
+        "split2": "^4.2.0",
+        "wait-port": "^1.1.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/utils/node_modules/decamelize": {
+      "version": "6.0.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@wdio/utils/node_modules/split2": {
+      "version": "4.2.0",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/@zip.js/zip.js": {
+      "version": "2.7.60",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "bun": ">=0.7.0",
+        "deno": ">=1.0.0",
+        "node": ">=16.5.0"
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -4372,11 +4470,8 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.1",
+      "version": "7.1.3",
       "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
       "engines": {
         "node": ">= 14"
       }
@@ -4441,72 +4536,83 @@
       "license": "MIT"
     },
     "node_modules/archiver": {
-      "version": "5.3.2",
+      "version": "7.0.1",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "archiver-utils": "^2.1.0",
+        "archiver-utils": "^5.0.2",
         "async": "^3.2.4",
-        "buffer-crc32": "^0.2.1",
-        "readable-stream": "^3.6.0",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
         "readdir-glob": "^1.1.2",
-        "tar-stream": "^2.2.0",
-        "zip-stream": "^4.1.0"
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 14"
       }
     },
     "node_modules/archiver-utils": {
-      "version": "2.1.0",
+      "version": "5.0.2",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "glob": "^7.1.4",
+        "glob": "^10.0.0",
         "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
         "lazystream": "^1.0.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.difference": "^4.5.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.union": "^4.6.0",
+        "lodash": "^4.17.15",
         "normalize-path": "^3.0.0",
-        "readable-stream": "^2.0.0"
+        "readable-stream": "^4.0.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
-    "node_modules/archiver-utils/node_modules/glob": {
-      "version": "7.2.3",
-      "license": "ISC",
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/archiver/node_modules/readable-stream": {
-      "version": "3.6.2",
+      "version": "4.7.0",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/argparse": {
@@ -4681,6 +4787,17 @@
         "node": "*"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "license": "MIT",
@@ -4711,6 +4828,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/b4a": {
+      "version": "1.6.7",
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.11",
@@ -4760,6 +4882,73 @@
       "version": "1.0.2",
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.5.4",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/bare-fs": {
+      "version": "4.0.2",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.6.1",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.6.5",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "streamx": "^2.21.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "funding": [
@@ -4785,6 +4974,14 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/basic-ftp": {
+      "version": "5.0.5",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/before-after-hook": {
       "version": "3.0.2",
       "dev": true,
@@ -4795,55 +4992,14 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/bl/node_modules/buffer": {
-      "version": "5.7.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/bn.js": {
       "version": "5.2.1",
       "license": "MIT"
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/bottleneck": {
       "version": "2.19.5",
@@ -4959,11 +5115,11 @@
       }
     },
     "node_modules/buffer-crc32": {
-      "version": "0.2.13",
+      "version": "1.0.0",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": "*"
+        "node": ">=8.0.0"
       }
     },
     "node_modules/buffer-from": {
@@ -4979,56 +5135,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/cacheable-lookup": {
-      "version": "5.0.4",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10.6.0"
-      }
-    },
-    "node_modules/cacheable-request": {
-      "version": "7.0.4",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^4.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^6.0.1",
-        "responselike": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/get-stream": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/normalize-url": {
-      "version": "6.1.0",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/call-bind": {
@@ -5179,37 +5285,75 @@
         "node": "*"
       }
     },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "license": "ISC",
-      "peer": true
-    },
-    "node_modules/chrome-launcher": {
-      "version": "0.15.2",
-      "license": "Apache-2.0",
+    "node_modules/cheerio": {
+      "version": "1.0.0",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@types/node": "*",
-        "escape-string-regexp": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "lighthouse-logger": "^1.0.0"
-      },
-      "bin": {
-        "print-chrome-path": "bin/print-chrome-path.js"
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "encoding-sniffer": "^0.2.0",
+        "htmlparser2": "^9.1.0",
+        "parse5": "^7.1.2",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^6.19.5",
+        "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=18.17"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
       }
     },
-    "node_modules/chrome-launcher/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cheerio/node_modules/parse5": {
+      "version": "7.2.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "entities": "^4.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/undici": {
+      "version": "6.21.2",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=18.17"
       }
     },
     "node_modules/ci-info": {
@@ -5360,7 +5504,6 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -5377,17 +5520,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/clone-response": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "mimic-response": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/color-convert": {
@@ -5439,30 +5571,41 @@
       }
     },
     "node_modules/compress-commons": {
-      "version": "4.1.2",
+      "version": "6.0.2",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "buffer-crc32": "^0.2.13",
-        "crc32-stream": "^4.0.2",
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
         "normalize-path": "^3.0.0",
-        "readable-stream": "^3.6.0"
+        "readable-stream": "^4.0.0"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 14"
       }
     },
     "node_modules/compress-commons/node_modules/readable-stream": {
-      "version": "3.6.2",
+      "version": "4.7.0",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/compress-commons/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/concat-map": {
@@ -5613,74 +5756,38 @@
       }
     },
     "node_modules/crc32-stream": {
-      "version": "4.0.3",
+      "version": "6.0.0",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
-        "readable-stream": "^3.4.0"
+        "readable-stream": "^4.0.0"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 14"
       }
     },
     "node_modules/crc32-stream/node_modules/readable-stream": {
-      "version": "3.6.2",
+      "version": "4.7.0",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "3.1.5",
+    "node_modules/crc32-stream/node_modules/string_decoder": {
+      "version": "1.3.0",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "node-fetch": "2.6.7"
-      }
-    },
-    "node_modules/cross-fetch/node_modules/node-fetch": {
-      "version": "2.6.7",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/cross-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/cross-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "license": "BSD-2-Clause",
-      "peer": true
-    },
-    "node_modules/cross-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -5720,6 +5827,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/css-shorthand-properties": {
       "version": "1.1.1",
       "peer": true
@@ -5727,6 +5849,17 @@
     "node_modules/css-value": {
       "version": "0.0.1",
       "peer": true
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
     },
     "node_modules/cssstyle": {
       "version": "4.0.1",
@@ -5914,31 +6047,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decompress-response/node_modules/mimic-response": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/deep-eql": {
       "version": "4.1.4",
       "dev": true,
@@ -5963,26 +6071,18 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "license": "MIT",
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "license": "BSD-3-Clause",
       "peer": true,
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/defekt": {
       "version": "9.3.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/defer-to-connect": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -6015,6 +6115,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "license": "MIT",
@@ -6029,171 +6142,6 @@
       "peer": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/devtools": {
-      "version": "7.35.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "^18.0.0",
-        "@types/ua-parser-js": "^0.7.33",
-        "@wdio/config": "7.33.0",
-        "@wdio/logger": "7.26.0",
-        "@wdio/protocols": "7.27.0",
-        "@wdio/types": "7.33.0",
-        "@wdio/utils": "7.33.0",
-        "chrome-launcher": "^0.15.0",
-        "edge-paths": "^2.1.0",
-        "puppeteer-core": "13.1.3",
-        "query-selector-shadow-dom": "^1.0.0",
-        "ua-parser-js": "^1.0.1",
-        "uuid": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/devtools-protocol": {
-      "version": "0.0.1260888",
-      "license": "BSD-3-Clause",
-      "peer": true
-    },
-    "node_modules/devtools/node_modules/agent-base": {
-      "version": "6.0.2",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/devtools/node_modules/debug": {
-      "version": "4.3.2",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/devtools/node_modules/devtools-protocol": {
-      "version": "0.0.948846",
-      "license": "BSD-3-Clause",
-      "peer": true
-    },
-    "node_modules/devtools/node_modules/glob": {
-      "version": "7.2.3",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/devtools/node_modules/https-proxy-agent": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/devtools/node_modules/node-fetch": {
-      "version": "2.6.7",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/devtools/node_modules/puppeteer-core": {
-      "version": "13.1.3",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "debug": "4.3.2",
-        "devtools-protocol": "0.0.948846",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.0",
-        "node-fetch": "2.6.7",
-        "pkg-dir": "4.2.0",
-        "progress": "2.0.3",
-        "proxy-from-env": "1.1.0",
-        "rimraf": "3.0.2",
-        "tar-fs": "2.1.1",
-        "unbzip2-stream": "1.4.3",
-        "ws": "8.2.3"
-      },
-      "engines": {
-        "node": ">=10.18.1"
-      }
-    },
-    "node_modules/devtools/node_modules/rimraf": {
-      "version": "3.0.2",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/devtools/node_modules/tr46": {
-      "version": "0.0.3",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/devtools/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "license": "BSD-2-Clause",
-      "peer": true
-    },
-    "node_modules/devtools/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/dexie": {
@@ -6272,6 +6220,57 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dot-prop": {
       "version": "5.3.0",
       "dev": true,
@@ -6291,13 +6290,80 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/edge-paths": {
-      "version": "2.2.1",
+      "version": "3.0.5",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@types/which": "^1.3.2",
+        "@types/which": "^2.0.1",
         "which": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/shirshak55"
+      }
+    },
+    "node_modules/edgedriver": {
+      "version": "6.1.1",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@wdio/logger": "^9.1.3",
+        "@zip.js/zip.js": "^2.7.53",
+        "decamelize": "^6.0.0",
+        "edge-paths": "^3.0.5",
+        "fast-xml-parser": "^4.5.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "node-fetch": "^3.3.2",
+        "which": "^5.0.0"
+      },
+      "bin": {
+        "edgedriver": "bin/edgedriver.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/edgedriver/node_modules/decamelize": {
+      "version": "6.0.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/edgedriver/node_modules/isexe": {
+      "version": "3.1.1",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/edgedriver/node_modules/which": {
+      "version": "5.0.0",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -6322,10 +6388,26 @@
       "version": "4.12.0",
       "license": "MIT"
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "license": "MIT"
+    },
     "node_modules/emojilib": {
       "version": "2.4.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -6736,7 +6818,6 @@
     },
     "node_modules/escalade": {
       "version": "3.1.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6748,6 +6829,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -7052,6 +7153,18 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "dev": true,
@@ -7076,15 +7189,21 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -7115,6 +7234,14 @@
       "version": "4.0.7",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -7171,10 +7298,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/fast-content-type-parse": {
+      "version": "2.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -7211,6 +7358,23 @@
       "version": "2.0.6",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.5.3",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "strnum": "^1.1.1"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -7391,6 +7555,32 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.0",
       "license": "MIT",
@@ -7427,13 +7617,9 @@
         "readable-stream": "^2.0.0"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/fs-extra": {
       "version": "11.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -7503,6 +7689,61 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/geckodriver": {
+      "version": "5.0.0",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@wdio/logger": "^9.1.3",
+        "@zip.js/zip.js": "^2.7.53",
+        "decamelize": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "node-fetch": "^3.3.2",
+        "tar-fs": "^3.0.6",
+        "which": "^5.0.0"
+      },
+      "bin": {
+        "geckodriver": "bin/geckodriver.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/geckodriver/node_modules/decamelize": {
+      "version": "6.0.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/geckodriver/node_modules/isexe": {
+      "version": "3.1.1",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/geckodriver/node_modules/which": {
+      "version": "5.0.0",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/generate-function": {
       "version": "2.3.1",
       "dev": true,
@@ -7534,7 +7775,6 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -7573,6 +7813,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-port": {
+      "version": "7.1.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "dev": true,
@@ -7598,6 +7849,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.4",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/get-uri/node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/git-log-parser": {
@@ -7631,18 +7903,19 @@
       }
     },
     "node_modules/glob": {
-      "version": "8.1.0",
+      "version": "10.4.5",
       "license": "ISC",
       "peer": true,
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
-      "engines": {
-        "node": ">=12"
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -7668,14 +7941,17 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "5.1.6",
+      "version": "9.0.5",
       "license": "ISC",
       "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -7732,30 +8008,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/got": {
-      "version": "11.8.6",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@sindresorhus/is": "^4.0.0",
-        "@szmarczak/http-timer": "^4.0.5",
-        "@types/cacheable-request": "^6.0.1",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.2",
-        "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.2",
-        "lowercase-keys": "^2.0.0",
-        "p-cancelable": "^2.0.0",
-        "responselike": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
     "node_modules/graceful-fs": {
@@ -7971,10 +8223,28 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/http-cache-semantics": {
-      "version": "4.1.1",
-      "license": "BSD-2-Clause",
+    "node_modules/htmlfy": {
+      "version": "0.6.5",
+      "license": "MIT",
       "peer": true
+    },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -7987,34 +8257,11 @@
         "node": ">= 14"
       }
     },
-    "node_modules/http2-wrapper": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
-      }
-    },
-    "node_modules/http2-wrapper/node_modules/quick-lru": {
-      "version": "5.1.1",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.5",
+      "version": "7.0.6",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
@@ -8080,6 +8327,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "dev": true,
@@ -8120,7 +8372,6 @@
     },
     "node_modules/import-meta-resolve": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -8197,6 +8448,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/is-arguments": {
@@ -8361,7 +8624,6 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8528,7 +8790,6 @@
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8782,6 +9043,20 @@
         "set-function-name": "^2.0.1"
       }
     },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/java-properties": {
       "version": "1.0.2",
       "dev": true,
@@ -8809,6 +9084,11 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jsdom": {
       "version": "24.1.3",
@@ -8896,6 +9176,7 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-better-errors": {
@@ -9053,6 +9334,22 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "peer": true,
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/pako": {
+      "version": "1.0.11",
+      "license": "(MIT AND Zlib)",
+      "peer": true
+    },
     "node_modules/just-extend": {
       "version": "6.2.0",
       "dev": true,
@@ -9064,6 +9361,7 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -9140,27 +9438,13 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lighthouse-logger": {
-      "version": "1.4.2",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "debug": "^2.6.9",
-        "marky": "^1.2.2"
-      }
-    },
-    "node_modules/lighthouse-logger/node_modules/debug": {
-      "version": "2.6.9",
+    "node_modules/lie": {
+      "version": "3.3.0",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "ms": "2.0.0"
+        "immediate": "~3.0.5"
       }
-    },
-    "node_modules/lighthouse-logger/node_modules/ms": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -9224,6 +9508,26 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/locate-app": {
+      "version": "2.5.0",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://buymeacoffee.com/hejny"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/hejny/locate-app/blob/main/README.md#%EF%B8%8F-contributing"
+        }
+      ],
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@promptbook/utils": "0.69.5",
+        "type-fest": "4.26.0",
+        "userhome": "1.0.1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "dev": true,
@@ -9240,7 +9544,6 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
@@ -9263,25 +9566,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.defaults": {
-      "version": "4.2.0",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/lodash.difference": {
-      "version": "4.5.0",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lodash.flatten": {
-      "version": "4.4.0",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
@@ -9298,13 +9586,9 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.isobject": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isstring": {
@@ -9314,12 +9598,8 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lodash.union": {
-      "version": "4.6.0",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/lodash.uniqby": {
       "version": "4.7.0",
@@ -9332,7 +9612,7 @@
       "peer": true
     },
     "node_modules/loglevel": {
-      "version": "1.9.1",
+      "version": "1.9.2",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -9378,14 +9658,6 @@
       "license": "MIT",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/lowercase-keys": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/lru-cache": {
@@ -9510,11 +9782,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/marky": {
-      "version": "1.2.5",
-      "license": "Apache-2.0",
-      "peer": true
-    },
     "node_modules/memory-pager": {
       "version": "1.5.0",
       "dev": true,
@@ -9620,14 +9887,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "dev": true,
@@ -9679,10 +9938,13 @@
         "node": ">= 6"
       }
     },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "license": "MIT",
-      "peer": true
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
     },
     "node_modules/mlly": {
       "version": "1.7.1",
@@ -9869,6 +10131,14 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/nise": {
       "version": "6.0.0",
@@ -12566,6 +12836,17 @@
       "inBundle": true,
       "license": "ISC"
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/nwsapi": {
       "version": "2.2.12",
       "license": "MIT",
@@ -12743,14 +13024,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/p-cancelable": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/p-each-series": {
       "version": "3.0.0",
       "dev": true,
@@ -12801,14 +13074,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/p-iteration": {
-      "version": "1.1.8",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/p-limit": {
@@ -12875,10 +13140,46 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "license": "BlueOak-1.0.0",
+      "peer": true
     },
     "node_modules/pako": {
       "version": "2.1.0",
@@ -12940,6 +13241,28 @@
       "version": "6.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream/node_modules/parse5": {
+      "version": "7.2.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "entities": "^4.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/patch-package": {
       "version": "8.0.0",
@@ -13069,6 +13392,7 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13092,6 +13416,26 @@
       "version": "1.0.7",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
@@ -13210,65 +13554,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/pkg-dir": {
-      "version": "4.2.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "find-up": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/find-up": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/locate-path": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-limit": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-locate": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/pkg-types": {
@@ -13421,6 +13706,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "license": "MIT"
@@ -13465,6 +13758,32 @@
         "url": "https://www.buymeacoffee.com/thesayyn"
       }
     },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "license": "MIT",
@@ -13476,7 +13795,7 @@
       "peer": true
     },
     "node_modules/pump": {
-      "version": "3.0.0",
+      "version": "3.0.2",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -13489,105 +13808,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/puppeteer-core": {
-      "version": "13.7.0",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "cross-fetch": "3.1.5",
-        "debug": "4.3.4",
-        "devtools-protocol": "0.0.981744",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.1",
-        "pkg-dir": "4.2.0",
-        "progress": "2.0.3",
-        "proxy-from-env": "1.1.0",
-        "rimraf": "3.0.2",
-        "tar-fs": "2.1.1",
-        "unbzip2-stream": "1.4.3",
-        "ws": "8.5.0"
-      },
-      "engines": {
-        "node": ">=10.18.1"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/agent-base": {
-      "version": "6.0.2",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/debug": {
-      "version": "4.3.4",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/devtools-protocol": {
-      "version": "0.0.981744",
-      "license": "BSD-3-Clause",
-      "peer": true
-    },
-    "node_modules/puppeteer-core/node_modules/glob": {
-      "version": "7.2.3",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/rimraf": {
-      "version": "3.0.2",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/q": {
@@ -13769,17 +13989,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/read-package-up/node_modules/type-fest": {
-      "version": "4.25.0",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg": {
@@ -14078,7 +14287,6 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14113,28 +14321,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/resolve-alpn": {
-      "version": "1.2.1",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/responselike": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lowercase-keys": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/resq": {
@@ -14362,6 +14554,14 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/safaridriver": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.2",
       "dev": true,
@@ -14381,7 +14581,6 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14907,25 +15106,25 @@
       }
     },
     "node_modules/serialize-error": {
-      "version": "8.1.0",
+      "version": "11.0.3",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "type-fest": "^0.20.2"
+        "type-fest": "^2.12.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/serialize-error/node_modules/type-fest": {
-      "version": "0.20.2",
+      "version": "2.19.0",
       "license": "(MIT OR CC0-1.0)",
       "peer": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -15169,6 +15368,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/socket.io-client": {
       "version": "4.7.2",
       "dev": true,
@@ -15195,9 +15403,35 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/socks": {
+      "version": "2.8.4",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -15210,6 +15444,21 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/spacetrim": {
+      "version": "0.11.59",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://buymeacoffee.com/hejny"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/hejny/spacetrim/blob/main/README.md#%EF%B8%8F-contributing"
+        }
+      ],
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
@@ -15284,6 +15533,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "dev": true,
@@ -15323,6 +15577,18 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.22.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "license": "MIT",
@@ -15336,7 +15602,6 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -15347,10 +15612,19 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT"
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.11",
@@ -15442,6 +15716,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "dev": true,
@@ -15487,6 +15773,17 @@
       "version": "9.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/super-regex": {
       "version": "1.0.0",
@@ -15565,42 +15862,26 @@
       "peer": true
     },
     "node_modules/tar-fs": {
-      "version": "2.1.1",
+      "version": "3.0.8",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
       }
     },
     "node_modules/tar-stream": {
-      "version": "2.2.0",
+      "version": "3.1.7",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tar-stream/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
       }
     },
     "node_modules/temp-dir": {
@@ -15712,6 +15993,14 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
     "node_modules/text-extensions": {
       "version": "1.9.0",
       "dev": true,
@@ -15746,6 +16035,7 @@
     },
     "node_modules/through": {
       "version": "2.3.8",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/through2": {
@@ -15812,14 +16102,6 @@
       },
       "engines": {
         "node": ">=0.6.0"
-      }
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/to-regex-range": {
@@ -15937,6 +16219,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.26.0",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -16104,7 +16396,7 @@
     },
     "node_modules/typescript": {
       "version": "4.9.5",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -16112,28 +16404,6 @@
       },
       "engines": {
         "node": ">=4.2.0"
-      }
-    },
-    "node_modules/ua-parser-js": {
-      "version": "1.0.38",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ufo": {
@@ -16172,38 +16442,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/unbzip2-stream": {
-      "version": "1.4.3",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "buffer": "^5.2.1",
-        "through": "^2.3.8"
-      }
-    },
-    "node_modules/unbzip2-stream/node_modules/buffer": {
-      "version": "5.7.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/undici": {
@@ -16363,6 +16601,19 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/userhome": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/util": {
       "version": "0.12.5",
       "dev": true,
@@ -16381,6 +16632,7 @@
     },
     "node_modules/uuid": {
       "version": "9.0.1",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -16408,7 +16660,7 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.14",
+      "version": "5.4.16",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16466,7 +16718,7 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16487,15 +16739,15 @@
       }
     },
     "node_modules/vitest": {
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "1.6.0",
-        "@vitest/runner": "1.6.0",
-        "@vitest/snapshot": "1.6.0",
-        "@vitest/spy": "1.6.0",
-        "@vitest/utils": "1.6.0",
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
         "acorn-walk": "^8.3.2",
         "chai": "^4.3.10",
         "debug": "^4.3.4",
@@ -16509,7 +16761,7 @@
         "tinybench": "^2.5.1",
         "tinypool": "^0.8.3",
         "vite": "^5.0.0",
-        "vite-node": "1.6.0",
+        "vite-node": "1.6.1",
         "why-is-node-running": "^2.2.2"
       },
       "bin": {
@@ -16524,8 +16776,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "1.6.0",
-        "@vitest/ui": "1.6.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -16695,6 +16947,94 @@
         "node": ">=18"
       }
     },
+    "node_modules/wait-port": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "commander": "^9.3.0",
+        "debug": "^4.3.4"
+      },
+      "bin": {
+        "wait-port": "bin/wait-port.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/wait-port/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wait-port/node_modules/chalk": {
+      "version": "4.1.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/wait-port/node_modules/color-convert": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wait-port/node_modules/color-name": {
+      "version": "1.1.4",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/wait-port/node_modules/commander": {
+      "version": "9.5.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/wait-port/node_modules/has-flag": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wait-port/node_modules/supports-color": {
+      "version": "7.2.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "license": "MIT",
@@ -16703,70 +17043,95 @@
       }
     },
     "node_modules/webdriver": {
-      "version": "7.33.0",
+      "version": "9.12.2",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@types/node": "^18.0.0",
-        "@wdio/config": "7.33.0",
-        "@wdio/logger": "7.26.0",
-        "@wdio/protocols": "7.27.0",
-        "@wdio/types": "7.33.0",
-        "@wdio/utils": "7.33.0",
-        "got": "^11.0.2",
-        "ky": "0.30.0",
-        "lodash.merge": "^4.6.1"
+        "@types/node": "^20.1.0",
+        "@types/ws": "^8.5.3",
+        "@wdio/config": "9.12.2",
+        "@wdio/logger": "9.4.4",
+        "@wdio/protocols": "9.12.2",
+        "@wdio/types": "9.12.2",
+        "@wdio/utils": "9.12.2",
+        "deepmerge-ts": "^7.0.3",
+        "undici": "^6.20.1",
+        "ws": "^8.8.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.20.0"
       }
     },
-    "node_modules/webdriver/node_modules/ky": {
-      "version": "0.30.0",
+    "node_modules/webdriver/node_modules/@types/node": {
+      "version": "20.17.29",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/webdriver/node_modules/undici": {
+      "version": "6.21.2",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/ky?sponsor=1"
+        "node": ">=18.17"
       }
+    },
+    "node_modules/webdriver/node_modules/undici-types": {
+      "version": "6.19.8",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/webdriverio": {
-      "version": "7.36.0",
+      "version": "9.12.2",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@types/aria-query": "^5.0.0",
-        "@types/node": "^18.0.0",
-        "@wdio/config": "7.33.0",
-        "@wdio/logger": "7.26.0",
-        "@wdio/protocols": "7.27.0",
-        "@wdio/repl": "7.33.0",
-        "@wdio/types": "7.33.0",
-        "@wdio/utils": "7.33.0",
-        "archiver": "^5.0.0",
-        "aria-query": "^5.2.1",
+        "@types/node": "^20.11.30",
+        "@types/sinonjs__fake-timers": "^8.1.5",
+        "@wdio/config": "9.12.2",
+        "@wdio/logger": "9.4.4",
+        "@wdio/protocols": "9.12.2",
+        "@wdio/repl": "9.4.4",
+        "@wdio/types": "9.12.2",
+        "@wdio/utils": "9.12.2",
+        "archiver": "^7.0.1",
+        "aria-query": "^5.3.0",
+        "cheerio": "^1.0.0-rc.12",
         "css-shorthand-properties": "^1.1.1",
         "css-value": "^0.0.1",
-        "devtools": "7.35.0",
-        "devtools-protocol": "^0.0.1260888",
-        "fs-extra": "^11.1.1",
-        "grapheme-splitter": "^1.0.2",
+        "grapheme-splitter": "^1.0.4",
+        "htmlfy": "^0.6.0",
+        "is-plain-obj": "^4.1.0",
+        "jszip": "^3.10.1",
         "lodash.clonedeep": "^4.5.0",
-        "lodash.isobject": "^3.0.2",
-        "lodash.isplainobject": "^4.0.6",
         "lodash.zip": "^4.2.0",
-        "minimatch": "^6.0.4",
-        "puppeteer-core": "^13.1.3",
-        "query-selector-shadow-dom": "^1.0.0",
-        "resq": "^1.9.1",
+        "query-selector-shadow-dom": "^1.0.1",
+        "resq": "^1.11.0",
         "rgb2hex": "0.2.5",
-        "serialize-error": "^8.0.0",
-        "webdriver": "7.33.0"
+        "serialize-error": "^11.0.3",
+        "urlpattern-polyfill": "^10.0.0",
+        "webdriver": "9.12.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.20.0"
+      },
+      "peerDependencies": {
+        "puppeteer-core": "^22.3.0"
+      },
+      "peerDependenciesMeta": {
+        "puppeteer-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webdriverio/node_modules/@types/node": {
+      "version": "20.17.29",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/webdriverio/node_modules/aria-query": {
@@ -16777,27 +17142,21 @@
         "dequal": "^2.0.3"
       }
     },
-    "node_modules/webdriverio/node_modules/brace-expansion": {
-      "version": "2.0.1",
+    "node_modules/webdriverio/node_modules/is-plain-obj": {
+      "version": "4.1.0",
       "license": "MIT",
       "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/webdriverio/node_modules/minimatch": {
-      "version": "6.2.0",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/webdriverio/node_modules/undici-types": {
+      "version": "6.19.8",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
@@ -16955,7 +17314,6 @@
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -16969,9 +17327,55 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/color-name": {
+      "version": "1.1.4",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -16985,7 +17389,6 @@
     },
     "node_modules/wrap-ansi/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -16996,7 +17399,6 @@
     },
     "node_modules/wrap-ansi/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrappy": {
@@ -17052,7 +17454,6 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -17065,7 +17466,6 @@
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -17090,7 +17490,6 @@
     },
     "node_modules/yargs/node_modules/yargs-parser": {
       "version": "21.1.1",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -17103,6 +17502,14 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yauzl/node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/yocto-queue": {
@@ -17156,68 +17563,39 @@
       }
     },
     "node_modules/zip-stream": {
-      "version": "4.1.1",
+      "version": "6.0.1",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "archiver-utils": "^3.0.4",
-        "compress-commons": "^4.1.2",
-        "readable-stream": "^3.6.0"
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
       },
       "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/zip-stream/node_modules/archiver-utils": {
-      "version": "3.0.4",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "glob": "^7.2.3",
-        "graceful-fs": "^4.2.0",
-        "lazystream": "^1.0.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.difference": "^4.5.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.union": "^4.6.0",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/zip-stream/node_modules/glob": {
-      "version": "7.2.3",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": ">= 14"
       }
     },
     "node_modules/zip-stream/node_modules/readable-stream": {
-      "version": "3.6.2",
+      "version": "4.7.0",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/zip-stream/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "elliptic": "^6.5.4",
     "jsdom": "^24.1.0",
     "rxjs": "^7.8.1",
-    "webdriverio": "^7.16.4"
+    "webdriverio": "^9.12.2"
   },
   "overrides": {
     "ws": "^8.17.1"

--- a/src/plugins/internal/dif/PresentationVerify.ts
+++ b/src/plugins/internal/dif/PresentationVerify.ts
@@ -278,31 +278,25 @@ export class PresentationVerify extends Plugins.Task<Args> {
     const fields = constraints.fields;
 
     if (constraints.limit_disclosure === "required") {
+      const requiredFields = fields.filter((field) => !field.optional);
 
-      for (const field of fields) {
+      for (const field of requiredFields) {
         const paths = [...field.path];
-        const optional = field.optional;
-
-        if (!optional) {
-          let error: Error | undefined;
-          while (paths.length) {
-            const [path] = paths.splice(0, 1);
-            try {
-              const valid = this.validateField(vc, descriptorMapper, path, field);
-              if (valid) {
-                break;
-              }
-              //if field is valid, stop searching paths
-              error = undefined;
-              break;
-            } catch (err) {
-              //set error and continue to see if other paths succeed
-              error ??= err as Error;
-            }
+        let error: Error | undefined;
+        while (paths.length) {
+          const [path] = paths.splice(0, 1);
+          try {
+            //throws an exception or returns true if it's valid
+            this.validateField(vc, descriptorMapper, path, field);
+            error = undefined;
+            break;
+          } catch (err) {
+            //set error and continue to see if other paths succeed
+            error ??= err as Error;
           }
-          if (error) {
-            throw error
-          }
+        }
+        if (error) {
+          throw error
         }
       }
     }


### PR DESCRIPTION


### Description: 
Simple fix for a bug found during integration tests, when the first input descriptor path is not found but is instead in a secondary path.

Added an improvement in the validateInputDescriptor function and fixed the issue

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
