### PR TITLE
test(e2e): removing use of store.clear

### DIFF
--- a/integration-tests/e2e-tests/src/abilities/WalletSdk.ts
+++ b/integration-tests/e2e-tests/src/abilities/WalletSdk.ts
@@ -139,7 +139,6 @@ export class WalletSdk extends Ability implements Initialisable, Discardable {
   async discard(): Promise<void> {
     agentList.delete(this.id)
     if (this.isInitialised()) {
-      await this.store.clear()
       await this.sdk.stop()
     }
   }


### PR DESCRIPTION
### Description: 
Calling `agent.stop` and `store.clear` results in an error as both clear the internal db.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
