### PR TITLE
feat!: Anoncreds moving to plugin export

### DIFF
--- a/integration-tests/e2e-tests/package-lock.json
+++ b/integration-tests/e2e-tests/package-lock.json
@@ -61,16 +61,6 @@
         "postinstall-postinstall": "^2.1.0"
       },
       "devDependencies": {
-        "@babel/core": "^7.20.12",
-        "@babel/plugin-proposal-class-properties": "^7.16.0",
-        "@babel/plugin-proposal-decorators": "^7.21.0",
-        "@babel/plugin-transform-typescript": "^7.21.0",
-        "@babel/preset-env": "^7.20.2",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.21.0",
-        "@droppedcode/typedoc-plugin-relative-includes": "^1.0.5",
-        "@esbuild-plugins/node-resolve": "^0.2.2",
-        "@pluto-encrypted/inmemory": "^1.12.3",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/commit-analyzer": "^9.0.2",
         "@semantic-release/exec": "^6.0.3",
@@ -89,12 +79,9 @@
         "@vitest/browser": "^1.6.0",
         "@vitest/coverage-istanbul": "^1.6.0",
         "anoncreds-wasm": "./externals/generated/anoncreds-wasm",
-        "babel-plugin-transform-typescript-metadata": "^0.3.2",
         "chai": "^4.3.7",
         "chai-as-promised": "^7.1.1",
-        "conventional-changelog-conventionalcommits": "^8.0.0",
         "didcomm-wasm": "./externals/generated/didcomm-wasm",
-        "esbuild": "0.21.5",
         "eslint": "^8.36.0",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-unused-imports": "^2.0.0",
@@ -106,12 +93,12 @@
         "semantic-release": "^24.0.0",
         "sinon": "^18.0.0",
         "sinon-chai": "^3.7.0",
+        "tsup": "^8.4.0",
         "typedoc": "^0.25.2",
         "typedoc-plugin-external-module-map": "^1.3.2",
         "typedoc-plugin-markdown": "^3.17.1",
         "typedoc-plugin-rename-defaults": "^0.7.0",
         "typescript": "^4.9.5",
-        "vite": "^5.4.0",
         "vitest": "^1.6.0"
       },
       "optionalDependencies": {
@@ -119,14 +106,12 @@
         "@rollup/rollup-linux-x64-gnu": "^4.24.0"
       },
       "peerDependencies": {
-        "@playwright/test": "^1.45.1",
         "@types/elliptic": "^6.4.16",
         "buffer": "^6.0.3",
         "core-js": "^3.32.2",
         "elliptic": "^6.5.4",
         "jsdom": "^24.1.0",
-        "rxjs": "^7.8.1",
-        "webdriverio": "^7.16.4"
+        "rxjs": "^7.8.1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/integration-tests/e2e-tests/src/abilities/WalletSdk.ts
+++ b/integration-tests/e2e-tests/src/abilities/WalletSdk.ts
@@ -1,5 +1,6 @@
 import { Ability, Discardable, Initialisable, Interaction, Question, QuestionAdapter } from "@serenity-js/core"
-import SDK from "@hyperledger/identus-sdk"
+import SDK from "@hyperledger/identus-sdk";
+import * as Anoncreds from "@hyperledger/identus-sdk/plugins/anoncreds";
 import axios from "axios"
 import { CloudAgentConfiguration } from "../configuration/CloudAgentConfiguration"
 import { randomUUID, UUID } from "crypto"
@@ -102,8 +103,8 @@ export class WalletSdk extends Ability implements Initialisable, Discardable {
       pluto,
       mediatorDID,
       castor
-    })
-    this.sdk.plugins.register(SDK.Plugins.Anoncreds)
+    });
+    this.sdk.plugins.register(Anoncreds.plugin);
 
     this.sdk.addListener(
       SDK.ListenerKey.MESSAGE, async (messages: SDK.Domain.Message[]) => {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,12 @@
       "require": "./index.cjs",
       "default": "./index.mjs"
     },
+    "./plugins/anoncreds": {
+      "types": "./build/plugins/internal/anoncreds/index.d.ts",
+      "import": "./build/plugins/internal/anoncreds/index.js",
+      "require": "./build/plugins/internal/anoncreds/index.js",
+      "default": "./build/plugins/internal/anoncreds/index.js"
+    },
     "./plugins/oidc": {
       "types": "./build/plugins/internal/oidc/index.d.ts",
       "import": "./build/plugins/internal/oidc/index.js",
@@ -20,6 +26,9 @@
   },
   "typesVersions": {
     "*": {
+      "plugins/anoncreds": [
+        "./build/plugins/internal/oidc/index.d.ts"
+      ],
       "plugins/oidc": [
         "./build/plugins/internal/oidc/index.d.ts"
       ]

--- a/src/edge-agent/didcomm/CreatePresentationRequest.ts
+++ b/src/edge-agent/didcomm/CreatePresentationRequest.ts
@@ -4,8 +4,8 @@ import { RequestPresentation } from "../protocols/proofPresentation";
 import { CreatePeerDID } from "./CreatePeerDID";
 import { Task } from "../../utils/tasks";
 import { AgentContext } from "./Context";
-import { Context as ACContext } from "../../plugins/internal/anoncreds";
-import { Context as DIFContext } from "../../plugins/internal/dif";
+import type { Context as ACContext } from "../../plugins/internal/anoncreds/plugin";
+import type { Context as DIFContext } from "../../plugins/internal/dif";
 
 // TODO tmp workaround using plugins in Agent task
 type TaskContext = AgentContext & ACContext & DIFContext;

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,11 +50,7 @@ export { JWTCredential, JWTVerifiableCredentialRecoveryId } from "./pollux/model
 export { SDJWTCredential, SDJWTVerifiableCredentialRecoveryId } from "./pollux/models/SDJWTVerifiableCredential";
 export * from "./pollux/models/AnonCredsVerifiableCredential";
 
-// plugins
-import AnoncredsPlugin from "./plugins/internal/anoncreds";
-export const Plugins = {
-  Anoncreds: AnoncredsPlugin,
-};
+// plugins exported through /plugins/plugin_name
 
 // Tasks
 import { CreatePrismDID } from "./edge-agent/didFunctions";

--- a/src/plugins/internal/anoncreds/CredentialIssue.ts
+++ b/src/plugins/internal/anoncreds/CredentialIssue.ts
@@ -4,7 +4,7 @@ import { AnonCredsCredential } from "../../../pollux/models/AnonCredsVerifiableC
 import { expect } from "../../../utils";
 import { GetLinkSecret } from "./GetLinkSecret";
 import { FetchCredentialDefinition } from "./FetchCredentialDefinition";
-import type { Context } from "./index";
+import type { Context } from "./plugin";
 import * as Types from "./types";
 import { Plugins } from "../../../plugins";
 

--- a/src/plugins/internal/anoncreds/CredentialOffer.ts
+++ b/src/plugins/internal/anoncreds/CredentialOffer.ts
@@ -3,7 +3,7 @@ import { expect } from "../../../utils";
 import { Payload } from "../../../domain/protocols/Payload";
 import { GetLinkSecret } from "./GetLinkSecret";
 import { FetchCredentialDefinition } from "./FetchCredentialDefinition";
-import type { Context } from "./index";
+import type { Context } from "./plugin";
 import * as Types from "./types";
 import { Plugins } from "../../../plugins";
 

--- a/src/plugins/internal/anoncreds/FetchCredentialDefinition.ts
+++ b/src/plugins/internal/anoncreds/FetchCredentialDefinition.ts
@@ -1,5 +1,5 @@
 import { Task } from "../../../utils";
-import type { Context } from "./index";
+import type { Context } from "./plugin";
 import * as Types from "./types";
 
 interface Args {

--- a/src/plugins/internal/anoncreds/FetchSchema.ts
+++ b/src/plugins/internal/anoncreds/FetchSchema.ts
@@ -1,5 +1,5 @@
-import { AgentContext } from "../../../edge-agent/didcomm/Context";
 import { Task } from "../../../utils";
+import type { Context } from "./plugin";
 import * as Types from "./types";
 
 interface Args {
@@ -7,7 +7,7 @@ interface Args {
 }
 
 export class fetchSchema extends Task<Types.Schema, Args> {
-  async run(ctx: AgentContext) {
+  async run(ctx: Context) {
     const response = await ctx.Api.request("GET", this.args.uri);
     // [ ] validate <Anoncreds.CredentialSchemaType>
     return response.body as Types.Schema;

--- a/src/plugins/internal/anoncreds/GetLinkSecret.ts
+++ b/src/plugins/internal/anoncreds/GetLinkSecret.ts
@@ -1,6 +1,6 @@
 import { LinkSecret } from "../../../domain";
 import { Task, notNil } from "../../../utils";
-import type { Context } from "./index";
+import type { Context } from "./plugin";
 
 /**
  * Retrieve a LinkSecret for use with Anoncreds operations

--- a/src/plugins/internal/anoncreds/PresentationRequest.ts
+++ b/src/plugins/internal/anoncreds/PresentationRequest.ts
@@ -6,7 +6,7 @@ import { isObject, notEmptyString } from "../../../utils";
 import { FetchCredentialDefinition } from "./FetchCredentialDefinition";
 import { fetchSchema } from "./FetchSchema";
 import { GetLinkSecret } from "./GetLinkSecret";
-import type { Context } from "./index";
+import type { Context } from "./plugin";
 import * as Types from "./types";
 
 interface Args {

--- a/src/plugins/internal/anoncreds/PresentationVerify.ts
+++ b/src/plugins/internal/anoncreds/PresentationVerify.ts
@@ -4,7 +4,7 @@ import { FetchCredentialDefinition } from "./FetchCredentialDefinition";
 import { fetchSchema } from "./FetchSchema";
 import { Payload } from "../../../domain/protocols/Payload";
 import { notNil } from "../../../utils";
-import type { Context } from "./index";
+import type { Context } from "./plugin";
 import * as Types from "./types";
 import { Plugins } from "../../../plugins";
 

--- a/src/plugins/internal/anoncreds/index.ts
+++ b/src/plugins/internal/anoncreds/index.ts
@@ -1,18 +1,6 @@
-import { Plugin, Plugins } from "../../../plugins";
-import * as Types from "./types";
-import { AnoncredsLoader } from "./module/AnoncredsLoader";
-import { CredentialIssue } from "./CredentialIssue";
-import { CredentialOffer } from "./CredentialOffer";
-import { PresentationRequest } from "./PresentationRequest";
-import { PresentationVerify } from "./PresentationVerify";
+export * from "./module/AnoncredsLoader";
+export * from "./FetchCredentialDefinition";
+export * from "./FetchSchema";
 
-export type Context = Plugins.Context<{ Anoncreds: AnoncredsLoader; }>;
-
-const plugin = new Plugin()
-  .addModule("Anoncreds", new AnoncredsLoader())
-  .register(Types.CREDENTIAL_ISSUE, CredentialIssue)
-  .register(Types.CREDENTIAL_OFFER, CredentialOffer)
-  .register(Types.PRESENTATION, PresentationVerify)
-  .register(Types.PRESENTATION_REQUEST, PresentationRequest);
-
-export default plugin;
+export * from "./plugin";
+export * from "./types";

--- a/src/plugins/internal/anoncreds/plugin.ts
+++ b/src/plugins/internal/anoncreds/plugin.ts
@@ -1,0 +1,17 @@
+import { Plugin, Plugins } from "../..";
+import * as Types from "./types";
+import { AnoncredsLoader } from "./module/AnoncredsLoader";
+import { CredentialIssue } from "./CredentialIssue";
+import { CredentialOffer } from "./CredentialOffer";
+import { PresentationRequest } from "./PresentationRequest";
+import { PresentationVerify } from "./PresentationVerify";
+
+export type Modules = { Anoncreds: AnoncredsLoader; };
+export type Context = Plugins.Context<Modules>;
+
+export const plugin = new Plugin()
+  .addModule("Anoncreds", new AnoncredsLoader())
+  .register(Types.CREDENTIAL_ISSUE, CredentialIssue)
+  .register(Types.CREDENTIAL_OFFER, CredentialOffer)
+  .register(Types.PRESENTATION, PresentationVerify)
+  .register(Types.PRESENTATION_REQUEST, PresentationRequest);

--- a/src/plugins/internal/dif/index.ts
+++ b/src/plugins/internal/dif/index.ts
@@ -5,7 +5,7 @@ import { PresentationRequest } from "./PresentationRequest";
 import { PresentationVerify } from "./PresentationVerify";
 import { DIFModule } from "./module";
 import { DIF } from "./types";
-import type { Context as ACContext } from "../anoncreds";
+import type { Context as ACContext } from "../anoncreds/plugin";
 
 export type Modules = { DIF: DIFModule; };
 export type Context = Plugins.Context<Modules & ACContext>;

--- a/tests/agent/Agent.anoncreds.test.ts
+++ b/tests/agent/Agent.anoncreds.test.ts
@@ -32,7 +32,7 @@ import { ApiResponse, Pluto as IPluto, JWT } from "../../src/domain";
 import { Pluto } from "../../src/pluto/Pluto";
 import { Castor, Store } from "../../src";
 import { randomUUID } from "crypto";
-import AnoncredsModule from "../../src/plugins/internal/anoncreds";
+import { plugin as AnoncredsPlugin } from "../../src/plugins/internal/anoncreds/plugin";
 
 
 let agent: Agent;
@@ -88,7 +88,7 @@ describe("Agent Tests", () => {
       api,
     });
 
-    agent.plugins.register(AnoncredsModule);
+    agent.plugins.register(AnoncredsPlugin);
   });
 
   describe("Anoncreds", () => {
@@ -259,7 +259,7 @@ describe("Agent Tests", () => {
         const credential = new AnonCredsCredential(Fixtures.Credentials.Anoncreds.credential);
         const attachment = new AttachmentDescriptor(Fixtures.PresentationRequests.AnoncredsAttachment.data, "attach_1", undefined, undefined, "anoncreds/proof-request@v1.0");
         const request = new RequestPresentation(
-          { proofTypes: [] },
+          {},
           [attachment],
           didFrom,
           didTo

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -3,6 +3,7 @@ import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: [
     'src/index.ts',
+    'src/plugins/internal/anoncreds/index.ts',
     'src/plugins/internal/oidc/index.ts',
   ],
   outDir: "build",


### PR DESCRIPTION
### Description: 
Moving the Anoncreds code to a separate plugin import / export.
This further decouples the code and should enable downstream builds to completely exclude Anoncreds wasm.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
