### PR TITLE
test: vitest config properly loading wasm modules

### DIFF
--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import { defineConfig } from 'vitest/config'
+import path from "path";
 
 const getWasmJSContent = (file) => {
   const wasmBinary = fs.readFileSync(file);
@@ -27,6 +28,15 @@ export default defineConfig({
   resolve: {
     extensions: ['.ts', '.js', '.wasm'],
     mainFields: ['module', 'main'],
+    alias: {
+      // Add path aliases to match tsconfig.json
+      'jwe-wasm/jwe_rust_bg.wasm': path.resolve(__dirname, './externals/generated/jwe-wasm/jwe_rust_bg.wasm'),
+      'anoncreds-wasm/anoncreds_wasm_bg.wasm': path.resolve(__dirname, './externals/generated/anoncreds-wasm/anoncreds_wasm_bg.wasm'),
+      'didcomm-wasm/didcomm_js_bg.wasm': path.resolve(__dirname, './externals/generated/didcomm-wasm/didcomm_js_bg.wasm'),
+      'anoncreds-wasm': path.resolve(__dirname, './externals/generated/anoncreds-wasm'),
+      'didcomm-wasm': path.resolve(__dirname, './externals/generated/didcomm-wasm'),
+      'jwe-wasm': path.resolve(__dirname, './externals/generated/jwe-wasm')
+    },
   },
   test: {
     setupFiles: ['./tests/setup.ts'],


### PR DESCRIPTION
### Description: 
Fixes loading wasm modules on vitest, allowing all tests to run/pass

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
