### PR TITLE
fix: improve type inference for schemas

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export { default as Apollo } from "./apollo/Apollo";
 export { default as Castor } from "./castor/Castor";
 export { default as Mercury, type DIDCommProtocol, DIDCommWrapper } from "./mercury";
 export * from "./pluto";
+export * from "./pluto/collections";
 export * as Domain from "./domain";
 export * as Utils from "./utils";
 

--- a/src/pluto/collections/index.ts
+++ b/src/pluto/collections/index.ts
@@ -8,11 +8,10 @@ type CollectionCreate = {
   | MigrationStrategies;
 };
 
-type MakeCollections = (additional?: CollectionList) => CollectionList;
 
 export type CollectionList = Record<string, CollectionCreate>;
 
-export const makeCollections: MakeCollections = (
+export const makeCollections = (
   additional: CollectionList = {}
 ) => {
   return {

--- a/src/pluto/models/Schema.ts
+++ b/src/pluto/models/Schema.ts
@@ -1,5 +1,37 @@
 import type { SchemaType } from '@trust0/ridb-core';
 
+// Helper types for extracting properties from the interface
+type ExtractModelProperties<T> = Omit<T, 'uuid'>;
+type ModelPropertyNames<T> = keyof ExtractModelProperties<T>;
+
+// Helper types to distinguish between required and optional properties
+type RequiredKeys<T> = {
+  [K in keyof T]-?: {} extends Pick<T, K> ? never : K
+}[keyof T];
+
+// Extract only required properties (excluding uuid which is handled separately)
+type ModelRequiredKeys<T> = Exclude<RequiredKeys<T>, 'uuid'>;
+
+// Type to convert TypeScript types to schema property definitions
+type TypeToSchemaType<T> =
+  T extends string ? { type: 'string' }
+  : T extends number ? { type: 'number' }
+  : T extends boolean ? { type: 'boolean' }
+  : { type: 'string' }; // fallback
+
+// Type to create the properties object from the interface
+type SchemaProperties<T> = {
+  [K in keyof ExtractModelProperties<T>]: TypeToSchemaType<T[K]> & Record<string, any>
+};
+
+// The properly typed schema return type
+type TypedSchema<T> = SchemaType & {
+  required: Array<ModelRequiredKeys<T>>;
+  encrypted: Array<ModelPropertyNames<T>>;
+  properties: {
+    uuid: { type: 'string', maxLength: 60 }
+  } & SchemaProperties<T>;
+};
 
 type StringKeys<T> = Exclude<Extract<keyof T, string>, "uuid">;
 type KeysOf<T, X> = { [K in keyof T]-?: X extends T[K] ? K : never; }[StringKeys<T>];
@@ -28,8 +60,8 @@ interface SchemaGenerator<T> {
  * @param generator 
  * @returns 
  */
-export const schemaFactory = <T>(generator: (schema: SchemaGenerator<T>) => void) => {
-  const schema: SchemaType & { required: string[], encrypted: [] } = {
+export const schemaFactory = <T>(generator: (schema: SchemaGenerator<T>) => void): TypedSchema<T> => {
+  const schema: SchemaType & { required: string[], encrypted: string[] } = {
     version: 0,
     type: 'object',
     primaryKey: 'uuid',
@@ -50,5 +82,5 @@ export const schemaFactory = <T>(generator: (schema: SchemaGenerator<T>) => void
     setVersion: (version) => { schema.version = version; }
   });
 
-  return schema;
+  return schema as TypedSchema<T>;
 };


### PR DESCRIPTION
### Description: 
Improves the schemaFactory type inference, in the past we had declarative schemas which means no matter what schema u have it will always know which properties we have on each schema, if they are required, if not. 

This change just fixes an issue where the schemas are no longer inferred, and RIDB implementation doesn't know exactly what properties should be returned

Does not change the code, just improve types

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
