### PR TITLE
fix: credential migration to version 2 to upgrade validUntil to a num…

### DIFF
--- a/src/domain/models/Credential.ts
+++ b/src/domain/models/Credential.ts
@@ -47,7 +47,7 @@ export interface StorableCredential {
     credentialCreated?: string;
     credentialUpdated?: string;
     credentialSchema?: string;
-    validUntil?: string;
+    validUntil?: number;
     revoked?: boolean;
     availableClaims?: string[];
   };

--- a/src/pluto/models/Credential.ts
+++ b/src/pluto/models/Credential.ts
@@ -30,7 +30,7 @@ export interface Credential extends Model {
   credentialCreated?: string;
   credentialUpdated?: string;
   credentialSchema?: string;
-  validUntil?: string;
+  validUntil?: number;
   revoked?: boolean;
   // availableClaims?: string[];
   id: string;
@@ -45,11 +45,11 @@ export const CredentialSchema = schemaFactory<Credential>(schema => {
   schema.addProperty("string", "credentialCreated");
   schema.addProperty("string", "credentialUpdated");
   schema.addProperty("string", "credentialSchema");
-  schema.addProperty("string", "validUntil");
+  schema.addProperty("number", "validUntil");
   schema.addProperty("boolean", "revoked");
 
   schema.setEncrypted("dataJson");
-  schema.setVersion(1);
+  schema.setVersion(2);
 
   //V1
   schema.addProperty("string", "id");
@@ -80,5 +80,11 @@ export const CredentialMigration: MigrationStrategies = {
 
     }
     throw new PlutoError.UnknownCredentialTypeError();
+  },
+  2: function (document) {
+    return {
+      ...document,
+      validUntil: document.validUntil ? new Date(document.validUntil).getTime() : undefined
+    }
   }
 }

--- a/src/pollux/models/JWTVerifiableCredential.ts
+++ b/src/pollux/models/JWTVerifiableCredential.ts
@@ -439,9 +439,7 @@ export class JWTCredential
       credentialData: JSON.stringify(data),
       issuer: this.issuer,
       subject: this.properties.get(JWT.Claims.sub),
-      validUntil: this.isCredentialPayload(Object.fromEntries(this.properties)) ?
-        this.getProperty(JWT.Claims.exp) :
-        this.getProperty(JWT.Claims.exp),
+      validUntil: this.getProperty(JWT.Claims.exp),
       availableClaims: claims,
       revoked: this.revoked
     };

--- a/src/pollux/models/SDJWTVerifiableCredential.ts
+++ b/src/pollux/models/SDJWTVerifiableCredential.ts
@@ -150,7 +150,7 @@ export class SDJWTCredential extends Credential implements ProvableCredential, S
         return this.properties.get(SDJWT_VP_PROPS.revoked);
     }
 
-    toStorable(): { id: string; recoveryId: string; credentialData: string; issuer?: string | undefined; subject?: string | undefined; credentialCreated?: string | undefined; credentialUpdated?: string | undefined; credentialSchema?: string | undefined; validUntil?: string | undefined; revoked?: boolean | undefined; availableClaims?: string[] | undefined; } {
+    toStorable(): { id: string; recoveryId: string; credentialData: string; issuer?: string | undefined; subject?: string | undefined; credentialCreated?: string | undefined; credentialUpdated?: string | undefined; credentialSchema?: string | undefined; validUntil?: number | undefined; revoked?: boolean | undefined; availableClaims?: string[] | undefined; } {
         const id = this.id;
         const data = { id, ...Object.fromEntries(this.properties) };
         const claims = this.claims.map((claim) => typeof claim !== 'string' ? JSON.stringify(claim) : claim)


### PR DESCRIPTION
Simple migration of the credential schema to change the field validUntil from string to number.
No test added as migrations have been already proven and are external to this SDK.

Tests all pass

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
