### PR TITLE
fix: exposing task to create OOB Presentation request

### DIFF
--- a/src/edge-agent/didcomm/CreateOOBPresentationRequest.ts
+++ b/src/edge-agent/didcomm/CreateOOBPresentationRequest.ts
@@ -1,0 +1,61 @@
+
+import { uuid } from "@stablelib/uuid";
+import * as Domain from "../../domain";
+import { Task } from "../../utils/tasks";
+import { OfferCredential, OutOfBandInvitation } from "../../plugins/internal/didcomm";
+import { AgentContext } from "../Context";
+import { RequestPresentation } from "../../plugins/internal/oea/protocols/RequestPresentation";
+
+/**
+ * Asyncronously create and store a new peer did
+ *
+ * @async
+ * @param {Service[]} services
+ * @param {boolean} [updateMediator=false]
+ * @returns {Promise<DID>}
+ */
+
+interface Args {
+    baseUrl?: string,
+    from: Domain.DID,
+    goalCode?: string,
+    goal?: string,
+    accept?: string[],
+    presentationRequest: RequestPresentation
+}
+
+export class CreateOOBPresentationRequest extends Task<string, Args> {
+
+    get oobBody() {
+        return {
+            goal_code: this.args.goalCode ?? "issue-vc",
+            goal: this.args.goal ?? "Issue Credential",
+            accept: this.args.accept ?? ["didcomm/v2"],
+        }
+    }
+
+    get attachments() {
+        return [
+            new Domain.AttachmentDescriptor(
+                {
+                    json: this.args.presentationRequest.makeMessage()
+                },
+                "application/json",
+            )
+        ];
+    }
+
+    async run(_ctx: AgentContext): Promise<string> {
+        if (!this.args.presentationRequest || !(this.args.presentationRequest instanceof RequestPresentation)) {
+            throw new Error("Invalid presentation request");
+        }
+        const oobId = uuid();
+        const oob = new OutOfBandInvitation(
+            this.oobBody,
+            this.args.from.toString(),
+            oobId,
+            this.attachments
+        );
+        return Buffer.from(JSON.stringify(oob)).toString("base64")
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,12 +69,14 @@ import { CreateOOBOffer } from './edge-agent/didcomm/CreateOOBOffer';
 import { RunProtocol } from "./edge-agent/helpers/RunProtocol";
 import { CreatePresentationRequest } from "./plugins/internal/oea/tasks/CreatePresentationRequest";
 import { CreatePresentation } from "./plugins/internal/oea/tasks/CreatePresentation";
+import { CreateOOBPresentationRequest } from "./edge-agent/didcomm/CreateOOBPresentationRequest";
 
 export const Tasks = {
   RunProtocol,
   CreatePrismDID,
   PKInstance,
   CreateOOBOffer,
+  CreateOOBPresentationRequest,
   CreatePresentation,
   CreatePresentationRequest
 };


### PR DESCRIPTION
### Description: 
The SDK so far in ts exports ```SDK.OutOfBandInvitation```, you could put any DIDComm message inside and make it OOB.

I'm just adding a helper class to make creating OOBPresentation easier.
Will not be adding coverage, its just a wrapper for a message and we know it works, take a look at CreateOOBOffer.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
