### PR TITLE
fix: exposing plugins dif + oea types

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,12 @@
       "import": "./build/plugins/internal/oidc/index.js",
       "require": "./build/plugins/internal/oidc/index.js",
       "default": "./build/plugins/internal/oidc/index.js"
+    },
+    "./plugins/dif": {
+      "types": "./build/plugins/internal/dif/index.d.ts",
+      "import": "./build/plugins/internal/dif/index.js",
+      "require": "./build/plugins/internal/dif/index.js",
+      "default": "./build/plugins/internal/dif/index.js"
     }
   },
   "typesVersions": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,12 @@
       "import": "./build/plugins/internal/dif/index.js",
       "require": "./build/plugins/internal/dif/index.js",
       "default": "./build/plugins/internal/dif/index.js"
+    },
+    "./plugins/oea": {
+      "types": "./build/plugins/internal/oea/index.d.ts",
+      "import": "./build/plugins/internal/oea/index.js",
+      "require": "./build/plugins/internal/oea/index.js",
+      "default": "./build/plugins/internal/oea/index.js"
     }
   },
   "typesVersions": {

--- a/src/plugins/internal/dif/index.ts
+++ b/src/plugins/internal/dif/index.ts
@@ -9,7 +9,6 @@ import type { Context as ACContext } from "../anoncreds/plugin";
 
 export type Modules = { DIF: DIFModule; };
 export type Context = Plugins.Context<Modules & ACContext>;
-
 const plugin = new Plugin()
   .addModule("DIF", new DIFModule())
   .register(DIF.PRESENTATION_REQUEST, PresentationRequest)
@@ -17,4 +16,6 @@ const plugin = new Plugin()
   // ??? tmp workaround Revocation being extracted to separate handlers
   .register("revocation-check/prism/jwt", IsCredentialRevoked);
 
+
 export default plugin;
+export * from "./types";

--- a/src/plugins/internal/oea/index.ts
+++ b/src/plugins/internal/oea/index.ts
@@ -24,3 +24,5 @@ plugin.register(`credential-offer/${OEA.PRISM_SDJWT}`, sdjwt.CredentialOffer);
 plugin.register(`presentation-request/${OEA.PRISM_SDJWT}`, sdjwt.PresentationRequest);
 
 export default plugin;
+export * from "./types";
+

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -6,6 +6,7 @@ export default defineConfig({
     'src/plugins/internal/anoncreds/index.ts',
     'src/plugins/internal/didcomm/index.ts',
     'src/plugins/internal/oidc/index.ts',
+    'src/plugins/internal/dif/index.ts',
   ],
   outDir: "build",
   clean: true,

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -7,6 +7,7 @@ export default defineConfig({
     'src/plugins/internal/didcomm/index.ts',
     'src/plugins/internal/oidc/index.ts',
     'src/plugins/internal/dif/index.ts',
+    'src/plugins/internal/oea/index.ts',
   ],
   outDir: "build",
   clean: true,


### PR DESCRIPTION
## Description
We are not creating new functionality, but over time we have hidden some of the types used in DIF (presentation exchange) and oea, in order to expose this feature back we're just exposing the DIF and OEA plugin in package json.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
