### PR TITLE
fix: improve types

### DIFF
--- a/src/domain/protocols/Payload.ts
+++ b/src/domain/protocols/Payload.ts
@@ -1,15 +1,17 @@
+/* eslint-disable no-redeclare */
+/* eslint-disable @typescript-eslint/no-namespace */
 /**
  * General purpose struct to pass data around
  * 
  * enables simplistic data transfer and identification
  */
-export interface Payload {
+export interface Payload<T> {
   // Payload IDentifier
   pid: string;
   // any value
-  data: any;
+  data: T;
 }
 
 export namespace Payload {
-  export const make = (pid: string, data: any): Payload => ({ pid, data });
+  export const make = <T>(pid: string, data: T): Payload<T> => ({ pid, data });
 }

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -3,7 +3,7 @@ import type { Payload } from "../domain/protocols/Payload";
 import type { AgentContext } from "../edge-agent/Context";
 
 export namespace Plugins {
-  export abstract class Task<T = unknown> extends Utils.Task<Payload, T> {}
+  export abstract class Task<T = unknown, R = unknown> extends Utils.Task<Payload<R>, T> { }
 
   export type Context<T = Record<string, never>> = Utils.Task.Context<T & AgentContext>;
 }


### PR DESCRIPTION
### Description: 
Simple task to allow typescript to infer whatever is the response type when calling task plugins

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
