### PR TITLE
fix: manage short form dids during credential issuance correctly.

### DIFF
--- a/src/edge-agent/didFunctions/FindDIDSigningKeys.ts
+++ b/src/edge-agent/didFunctions/FindDIDSigningKeys.ts
@@ -3,6 +3,7 @@ import { Task } from "../../utils/tasks";
 import { AgentContext } from "../Context";
 import { isNil, notNil } from "../../utils";
 import type * as Domain from "../../domain";
+import { base64url } from "multiformats/bases/base64";
 
 interface Args {
   did: Domain.DID;
@@ -30,13 +31,35 @@ export class FindSigningKeys extends Task<SigningKeyData[], Args> {
 
     const keyData = keys.map(privateKey => {
       const publicKey = privateKey.publicKey();
-      const encoded = base58btc.encode(Uint8Array.from(publicKey.to.Buffer()));
-
-      return { privateKey, publicKey, encoded };
+      const decoded = Uint8Array.from(publicKey.to.Buffer())
+      const encoded = base58btc.encode(decoded);
+      const encodedBase64Url = base64url.baseEncode(decoded);
+      return { privateKey, publicKey, encoded, encodedBase64Url };
     });
 
     const signingKeyData = didDoc.authentication.reduce<SigningKeyData[]>((acc, method) => {
-      const data = keyData.find(x => x.encoded === method.publicKeyMultibase);
+      const data = keyData.find(x => {
+        if (method.publicKeyMultibase) {
+          return x.encoded === method.publicKeyMultibase
+        }
+        if (method.publicKeyJwk) {
+          if (x.publicKey.isExportable()) {
+            const resolvedJWK = x.publicKey.to.JWK()
+            if (method.publicKeyJwk.y) {
+              return resolvedJWK.kty === method.publicKeyJwk.kty &&
+                resolvedJWK.crv === method.publicKeyJwk.crv &&
+                resolvedJWK.x === method.publicKeyJwk.x &&
+                resolvedJWK.y === method.publicKeyJwk.y
+            }
+            return resolvedJWK.kty === method.publicKeyJwk.kty &&
+              resolvedJWK.crv === method.publicKeyJwk.crv &&
+              resolvedJWK.x === method.publicKeyJwk.x
+          }
+          return x.publicKey.curve === method.publicKeyJwk.crv &&
+            x.encodedBase64Url === method.publicKeyJwk.x
+        }
+        return false;
+      });
 
       return isNil(data) ? acc : acc.concat({
         kid: method.id,
@@ -44,13 +67,20 @@ export class FindSigningKeys extends Task<SigningKeyData[], Args> {
         privateKey: data.privateKey
       });
     }, []);
-
     return signingKeyData;
   }
 
   private async getKeys(ctx: AgentContext): Promise<Domain.PrivateKey[]> {
-    return notNil(this.args.privateKey)
-      ? [this.args.privateKey]
-      : ctx.Pluto.getDIDPrivateKeysByDID(this.args.did);
+    if (notNil(this.args.privateKey)) {
+      return [this.args.privateKey];
+    }
+    const privateKeys = await ctx.Pluto.getDIDPrivateKeysByDID(this.args.did)
+    if (privateKeys.length === 0) {
+      const prismDIDs = await ctx.Pluto.getAllPrismDIDs();
+      return prismDIDs.filter((did) => {
+        return did.did.toString().includes(this.args.did.toString())
+      }).map(({ privateKey }) => privateKey)
+    }
+    return privateKeys;
   }
 }

--- a/src/pollux/utils/jwt/CreateJwt.ts
+++ b/src/pollux/utils/jwt/CreateJwt.ts
@@ -37,8 +37,6 @@ export class CreateJWT extends Task<string, Args> {
       throw new Error("Key is not signable");
     }
 
-    // const kid = await this.getSigningKid(ctx, this.args.did, privateKey);
-
     // secp256k1 uses compact encoding while apollo returns der signatures so far
     const signer: Signer = privateKey.curve === Domain.Curve.SECP256K1
       ? ES256KSigner(privateKey.raw)

--- a/src/pollux/utils/jwt/CreateSDJWT.ts
+++ b/src/pollux/utils/jwt/CreateSDJWT.ts
@@ -1,9 +1,10 @@
 import * as Domain from "../../../domain";
 import { Task } from "../../../utils/tasks";
-import { SdJwtVcPayload, } from "@sd-jwt/sd-jwt-vc";
+import { SDJwtVcInstance, SdJwtVcPayload, } from "@sd-jwt/sd-jwt-vc";
 import type { DisclosureFrame } from '@sd-jwt/types';
 import { Plugins } from "../../../plugins";
 import { FindSigningKeys } from "../../../edge-agent/didFunctions/FindDIDSigningKeys";
+import { expect } from "../../../utils";
 
 /**
  * Asyncronously sign with a DID
@@ -17,28 +18,33 @@ import { FindSigningKeys } from "../../../edge-agent/didFunctions/FindDIDSigning
 
 interface Args {
   did: Domain.DID;
-  privateKey?: Domain.PrivateKey;
   payload: SdJwtVcPayload;
   header?: Partial<Domain.JWT.Header>;
   disclosureFrame: DisclosureFrame<SdJwtVcPayload>;
+  privateKey?: Domain.PrivateKey;
 }
 
 export class CreateSDJWT extends Task<string, Args> {
-  async run(ctx: Plugins.Context) {
-    const signingKeys = await ctx.run(new FindSigningKeys({ did: this.args.did }));
-    const signingKey = signingKeys.at(0);
 
-    if (!signingKey?.privateKey.isSignable()) {
+  async run(ctx: Plugins.Context) {
+    const signingKeys = await ctx.run(
+      new FindSigningKeys({
+        did: this.args.did,
+        privateKey: this.args.privateKey
+      })
+    );
+    const signingKey = signingKeys.at(0);
+    const keyId = signingKey?.kid;
+    const privateKey = expect(signingKey?.privateKey, "key not found");
+    if (!privateKey?.isSignable()) {
       throw new Error("Key is not signable");
     }
-
-    const jwt = await ctx.SDJWT.sign({
-      issuerDID: this.args.did,
-      privateKey: signingKey.privateKey,
-      payload: this.args.payload,
-      disclosureFrame: this.args.disclosureFrame,
-      kid: signingKey.kid
-    });
-    return jwt;
+    const config = ctx.SDJWT.getSKConfig(privateKey);
+    const sdjwt = new SDJwtVcInstance(config);
+    return sdjwt.issue(
+      this.args.payload,
+      this.args.disclosureFrame,
+      keyId ? { header: { kid: keyId } } : undefined
+    );
   }
 }

--- a/tests/agent/mocks/CastorMock.ts
+++ b/tests/agent/mocks/CastorMock.ts
@@ -3,7 +3,6 @@ import {
   DID,
   DIDDocument,
   PublicKey,
-  Service,
 } from "../../../src/domain";
 import { Castor } from "../../../src/domain/buildingBlocks/Castor";
 
@@ -24,12 +23,12 @@ export const CastorMock: Castor & typeof castorVars = {
   },
   createPrismDID(
     masterPublicKey: PublicKey,
-    services?: Service[] | undefined
+    services?: DIDDocument.Service[] | undefined
   ): Promise<DID> {
     return Promise.resolve(castorVars._prismDID)
   },
 
-  createPeerDID(publicKeys: PublicKey[], services: Service[]): Promise<DID> {
+  createPeerDID(publicKeys: PublicKey[], services: DIDDocument.Service[]): Promise<DID> {
     return Promise.resolve(castorVars._peerDID);
   },
 


### PR DESCRIPTION

### Description: 
Fixes https://github.com/hyperledger-identus/sdk-ts/issues/451 an issue that doesn't allow us to Issue Credentials using a published Short Form DID.

The Issuer Agent receives a ShortForm and tries to find the private keys to sign with, but those were stored with the LongForm version, this PR improves the code a little to make it look like JWT + adds unitary test coverage.

Have debugged and manually tested this

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
