### PR TITLE
chore: Upgrade Node.js to v4 and add npm upgrade step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,14 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
-          registry-url: 'https://registry.npmjs.org/'
+          node-version: 22
+          registry-url: "https://registry.npmjs.org/"
+
+      # Ensure npm version >= 11.5.1 (lowest supporting trusted publishing)
+      - name: Upgrade npm
+        run: npm install -g npm@^11.5.1
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -42,12 +46,12 @@ jobs:
 
       - name: Release
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           GIT_AUTHOR_EMAIL: ${{ steps.import_gpg.outputs.email }}
           GIT_COMMITTER_EMAIL: ${{ steps.import_gpg.outputs.email }}
           GIT_AUTHOR_NAME: ${{ steps.import_gpg.outputs.name }}
           GIT_COMMITTER_NAME: ${{ steps.import_gpg.outputs.name }}
         run: |
-          npm install
+          echo "Using npm version: $(npm -v)"
+          npm audit signatures
           npx semantic-release


### PR DESCRIPTION
Updated Node.js setup to version 22 and added npm upgrade step.

Migrate away from using tokens and into trusted publishers.