### PR TITLE
fix: extract operation hash in hex from the signed data

### DIFF
--- a/packages/lib/sdk/src/castor/methods/index.ts
+++ b/packages/lib/sdk/src/castor/methods/index.ts
@@ -14,6 +14,7 @@ export type {
   RemoveServiceActionData,
   UpdateServiceActionData,
   Metadata,
+  getOperationHash
 } from "./prism";
 export { PeerDIDMethod } from "./peer";
 

--- a/packages/lib/sdk/src/castor/methods/prism/index.ts
+++ b/packages/lib/sdk/src/castor/methods/prism/index.ts
@@ -167,6 +167,19 @@ export type Metadata = {
   operationHash: string;
 }
 
+export function getOperationHash(serializedOperation: Uint8Array): string {
+
+  const atalaObject = Protos.io.iohk.atala.prism.protos.AtalaObject.deserialize(serializedOperation);
+
+  const block = atalaObject.block_content;
+
+  const operation = block.operations[0].serialize();
+
+  const operationHash = Buffer.from(operation).toString("hex");
+
+  return operationHash;
+}
+
 /**
  * DID method implementation for `did:prism`.
  *


### PR DESCRIPTION

### Description

extract operation hash in hex from the signed data

### Checklist

- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
